### PR TITLE
ci: add the ci code used to package and release docker images

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -44,6 +44,8 @@ jobs:
           file: ./op-node/Dockerfile
           push: true
           tags: ${{ steps.image.outputs.IMAGE_ID }}:${{ steps.image.outputs.VERSION }},${{ steps.image.outputs.IMAGE_ID }}:latest
+          cache-from: type=registry,ref=${{ steps.image.outputs.IMAGE_ID }}:buildcache
+          cache-to: type=registry,ref=${{ steps.image.outputs.IMAGE_ID }}:buildcache,mode=max
 
   push-op-batcher:
     runs-on: ubuntu-latest
@@ -81,6 +83,8 @@ jobs:
           file: ./op-batcher/Dockerfile
           push: true
           tags: ${{ steps.image.outputs.IMAGE_ID }}:${{ steps.image.outputs.VERSION }},${{ steps.image.outputs.IMAGE_ID }}:latest
+          cache-from: type=registry,ref=${{ steps.image.outputs.IMAGE_ID }}:buildcache
+          cache-to: type=registry,ref=${{ steps.image.outputs.IMAGE_ID }}:buildcache,mode=max
   push-op-proposer:
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
@@ -117,3 +121,5 @@ jobs:
           file: ./op-proposer/Dockerfile
           push: true
           tags: ${{ steps.image.outputs.IMAGE_ID }}:${{ steps.image.outputs.VERSION }},${{ steps.image.outputs.IMAGE_ID }}:latest
+          cache-from: type=registry,ref=${{ steps.image.outputs.IMAGE_ID }}:buildcache
+          cache-to: type=registry,ref=${{ steps.image.outputs.IMAGE_ID }}:buildcache,mode=max

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,119 @@
+name: DockerImage build and push
+
+on:
+  push:
+    # Publish `v1.2.3` tags as releases.
+    tags:
+      - v*
+
+jobs:
+  # Push image to GitHub Packages.
+  push-op-node:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: ImageId
+        id: image
+        run: |
+          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/op-node
+
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "main" ] && VERSION=latest
+          echo "IMAGE_ID=$IMAGE_ID">>$GITHUB_OUTPUT
+          echo "VERSION=$VERSION">>$GITHUB_OUTPUT
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./op-node/Dockerfile
+          push: true
+          tags: ${{ steps.image.outputs.IMAGE_ID }}:${{ steps.image.outputs.VERSION }}
+
+  push-op-batcher:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: ImageId
+        id: image
+        run: |
+          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/op-batcher
+
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "main" ] && VERSION=latest
+          echo "IMAGE_ID=$IMAGE_ID">>$GITHUB_OUTPUT
+          echo "VERSION=$VERSION">>$GITHUB_OUTPUT
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./op-batcher/Dockerfile
+          push: true
+          tags: ${{ steps.image.outputs.IMAGE_ID }}:${{ steps.image.outputs.VERSION }}
+  push-op-proposer:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: ImageId
+        id: image
+        run: |
+          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/op-proposer
+
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "main" ] && VERSION=latest
+          echo "IMAGE_ID=$IMAGE_ID">>$GITHUB_OUTPUT
+          echo "VERSION=$VERSION">>$GITHUB_OUTPUT
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./op-proposer/Dockerfile
+          push: true
+          tags: ${{ steps.image.outputs.IMAGE_ID }}:${{ steps.image.outputs.VERSION }}

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -43,7 +43,7 @@ jobs:
           context: .
           file: ./op-node/Dockerfile
           push: true
-          tags: ${{ steps.image.outputs.IMAGE_ID }}:${{ steps.image.outputs.VERSION }}
+          tags: ${{ steps.image.outputs.IMAGE_ID }}:${{ steps.image.outputs.VERSION }},${{ steps.image.outputs.IMAGE_ID }}:latest
 
   push-op-batcher:
     runs-on: ubuntu-latest
@@ -80,7 +80,7 @@ jobs:
           context: .
           file: ./op-batcher/Dockerfile
           push: true
-          tags: ${{ steps.image.outputs.IMAGE_ID }}:${{ steps.image.outputs.VERSION }}
+          tags: ${{ steps.image.outputs.IMAGE_ID }}:${{ steps.image.outputs.VERSION }},${{ steps.image.outputs.IMAGE_ID }}:latest
   push-op-proposer:
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
@@ -116,4 +116,4 @@ jobs:
           context: .
           file: ./op-proposer/Dockerfile
           push: true
-          tags: ${{ steps.image.outputs.IMAGE_ID }}:${{ steps.image.outputs.VERSION }}
+          tags: ${{ steps.image.outputs.IMAGE_ID }}:${{ steps.image.outputs.VERSION }},${{ steps.image.outputs.IMAGE_ID }}:latest


### PR DESCRIPTION
add the ci code used to package and release docker images

Execution effect:
![image](https://github.com/bnb-chain/opbnb/assets/136572398/30f22eda-b123-467b-acc5-b183f144c195)
![image](https://github.com/bnb-chain/opbnb/assets/136572398/bdbf46e8-221c-4ab2-a4b3-eab4bad32722)
![image](https://github.com/bnb-chain/opbnb/assets/136572398/b24f5003-d867-4549-a06b-169cbb8722b3)

Note: 
Need to open the write permission of github_token, path: settings->Actions->General->Workflow permissions
![image](https://github.com/bnb-chain/opbnb/assets/136572398/30023ab0-fa32-40f3-9319-f5636c873fe9)
