### PR TITLE
feat: add support for external coordinator mode

### DIFF
--- a/op-e2e/actions/l2_sequencer.go
+++ b/op-e2e/actions/l2_sequencer.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ethereum-optimism/optimism/op-node/client"
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/metrics"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
@@ -46,9 +47,10 @@ func NewL2Sequencer(t Testing, log log.Logger, l1 derive.L1Fetcher, eng L2API, c
 	l1OriginSelector := &MockL1OriginSelector{
 		actual: driver.NewL1OriginSelector(log, cfg, seqConfDepthL1),
 	}
+	var coordinatorClient *client.CoordinatorClient
 	return &L2Sequencer{
 		L2Verifier:              *ver,
-		sequencer:               driver.NewSequencer(log, cfg, ver.derivation, attrBuilder, l1OriginSelector, metrics.NoopMetrics),
+		sequencer:               driver.NewSequencer(log, cfg, ver.derivation, coordinatorClient, attrBuilder, l1OriginSelector, metrics.NoopMetrics),
 		mockL1OriginSelector:    l1OriginSelector,
 		failL2GossipUnsafeBlock: nil,
 	}

--- a/op-e2e/actions/l2_verifier.go
+++ b/op-e2e/actions/l2_verifier.go
@@ -121,6 +121,10 @@ func (s *l2VerifierBackend) StopSequencer(ctx context.Context) (common.Hash, err
 	return common.Hash{}, errors.New("stopping the L2Verifier sequencer is not supported")
 }
 
+func (s *l2VerifierBackend) SequencerStopped(ctx context.Context) bool {
+	return true
+}
+
 func (s *L2Verifier) L2Finalized() eth.L2BlockRef {
 	return s.derivation.Finalized()
 }

--- a/op-node/client/coordinator.go
+++ b/op-node/client/coordinator.go
@@ -1,0 +1,39 @@
+package client
+
+import (
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+// CoordinatorClient is a client for the coordinator RPC.
+type CoordinatorClient struct {
+	sequencerId string
+	rpc         *rpc.Client
+}
+
+// NewCoordinatorClient creates a new client for the coordinator RPC.
+func NewCoordinatorClient(url string, sequencerId string) (*CoordinatorClient, error) {
+	rpc, err := rpc.Dial(url)
+	if err != nil {
+		return nil, err
+	}
+	return &CoordinatorClient{
+		sequencerId: sequencerId,
+		rpc:         rpc,
+	}, nil
+}
+
+// RequestBuildingBlock is called by the sequencer to request a building block when using coordinator-mode.
+func (c *CoordinatorClient) RequestBuildingBlock() bool {
+	var respErr error
+	err := c.rpc.Call(respErr, "coordinator_requestBuildingBlock", c.sequencerId)
+	if err != nil {
+		log.Warn("Failed to call coordinator_requestBuildingBlock", "error", err)
+		return false
+	}
+	if respErr != nil {
+		log.Warn("coordinator_requestBuildingBlock refused request", "error", respErr)
+		return false
+	}
+	return true
+}

--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -208,6 +208,24 @@ var (
 		EnvVar:   prefixEnvVar("L2_BACKUP_UNSAFE_SYNC_RPC_TRUST_RPC"),
 		Required: false,
 	}
+	CoordinatorEnabledFlag = cli.BoolFlag{
+		Name:     "coordinator.enabled",
+		Usage:    "Enable the external coordinator mode",
+		EnvVar:   prefixEnvVar("COORDINATOR_ENABLED"),
+		Required: false,
+	}
+	CoordinatorAddrFlag = cli.StringFlag{
+		Name:     "coordinator.addr",
+		Usage:    "Coordinator listening address",
+		EnvVar:   prefixEnvVar("COORDINATOR_ADDR"),
+		Required: false,
+	}
+	CoordinatorSequencerIdFlag = cli.StringFlag{
+		Name:     "coordinator.sequencer-id",
+		Usage:    "the sequencer id configured in the Coordinator, used by Coordinator to distinguish different sequencers",
+		EnvVar:   prefixEnvVar("COORDINATOR_SEQUENCER_ID"),
+		Required: false,
+	}
 )
 
 var requiredFlags = []cli.Flag{
@@ -245,6 +263,9 @@ var optionalFlags = []cli.Flag{
 	HeartbeatURLFlag,
 	BackupL2UnsafeSyncRPC,
 	BackupL2UnsafeSyncRPCTrustRPC,
+	CoordinatorEnabledFlag,
+	CoordinatorAddrFlag,
+	CoordinatorSequencerIdFlag,
 }
 
 // Flags contains the list of configuration options available to the binary.

--- a/op-node/node/api.go
+++ b/op-node/node/api.go
@@ -26,6 +26,7 @@ type driverClient interface {
 	SyncStatus(ctx context.Context) (*eth.SyncStatus, error)
 	BlockRefWithStatus(ctx context.Context, num uint64) (eth.L2BlockRef, *eth.SyncStatus, error)
 	ResetDerivationPipeline(context.Context) error
+	SequencerStopped(ctx context.Context) bool
 	StartSequencer(ctx context.Context, blockHash common.Hash) error
 	StopSequencer(context.Context) (common.Hash, error)
 }
@@ -51,6 +52,10 @@ func (n *adminAPI) ResetDerivationPipeline(ctx context.Context) error {
 	recordDur := n.m.RecordRPCServerRequest("admin_resetDerivationPipeline")
 	defer recordDur()
 	return n.dr.ResetDerivationPipeline(ctx)
+}
+
+func (n *adminAPI) SequencerStopped(ctx context.Context) bool {
+	return n.dr.SequencerStopped(ctx)
 }
 
 func (n *adminAPI) StartSequencer(ctx context.Context, blockHash common.Hash) error {

--- a/op-node/node/client.go
+++ b/op-node/node/client.go
@@ -36,6 +36,33 @@ type L1EndpointSetup interface {
 	Check() error
 }
 
+type CoordinatorConfig struct {
+	// Enabled is true when the driver should request permission from op-coordinator before building new blocks.
+	// Default is false.
+	Enabled bool
+
+	// The sequencer id configured in the coordinator, used by Coordinator to distinguish different sequencers.
+	// It must be unique and same as the name of the sequencer node configured in the Coordinator service.
+	SequencerId string
+
+	// Address of the Coordinator JSON-RPC endpoint to use (opcoordinator namespace required).
+	CoordinatorAddr string
+}
+
+func (cfg *CoordinatorConfig) Check() error {
+	if !cfg.Enabled {
+		return nil
+	}
+	if cfg.SequencerId == "" {
+		return errors.New("empty Sequencer Id")
+	}
+	if cfg.CoordinatorAddr == "" {
+		return errors.New("empty Coordinator Address")
+	}
+
+	return nil
+}
+
 type L2EndpointConfig struct {
 	L2EngineAddr string // Address of L2 Engine JSON-RPC endpoint to use (engine and eth namespace required)
 

--- a/op-node/node/config.go
+++ b/op-node/node/config.go
@@ -17,6 +17,8 @@ type Config struct {
 	L2     L2EndpointSetup
 	L2Sync L2SyncEndpointSetup
 
+	Coordinator CoordinatorConfig
+
 	Driver driver.Config
 
 	Rollup rollup.Config
@@ -85,6 +87,9 @@ func (cfg *Config) Check() error {
 	}
 	if err := cfg.Rollup.Check(); err != nil {
 		return fmt.Errorf("rollup config error: %w", err)
+	}
+	if err := cfg.Coordinator.Check(); err != nil {
+		return fmt.Errorf("coordinator config error: %w", err)
 	}
 	if err := cfg.Metrics.Check(); err != nil {
 		return fmt.Errorf("metrics config error: %w", err)

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -40,6 +40,8 @@ type OpNode struct {
 	tracer    Tracer                // tracer to get events for testing/debugging
 	runCfg    *RuntimeConfig        // runtime configurables
 
+	coordinatorClient *client.CoordinatorClient // Coordinator RPC
+
 	// some resources cannot be stopped directly, like the p2p gossipsub router (not our design),
 	// and depend on this ctx to be closed.
 	resourcesCtx   context.Context
@@ -81,6 +83,9 @@ func (n *OpNode) init(ctx context.Context, cfg *Config, snapshotLog log.Logger) 
 	if err := n.initL1(ctx, cfg); err != nil {
 		return err
 	}
+	if err := n.initOpCoordinator(ctx, cfg); err != nil {
+		return err
+	}
 	if err := n.initRuntimeConfig(ctx, cfg); err != nil {
 		return err
 	}
@@ -112,6 +117,22 @@ func (n *OpNode) initTracer(ctx context.Context, cfg *Config) error {
 	} else {
 		n.tracer = new(noOpTracer)
 	}
+	return nil
+}
+
+func (n *OpNode) initOpCoordinator(ctx context.Context, cfg *Config) error {
+	if err := cfg.Coordinator.Check(); err != nil {
+		return fmt.Errorf("coordinator config is invalid: %w", err)
+	}
+
+	if cfg.Coordinator.Enabled {
+		var err error
+		n.coordinatorClient, err = client.NewCoordinatorClient(cfg.Coordinator.CoordinatorAddr, cfg.Coordinator.SequencerId)
+		if err != nil {
+			return fmt.Errorf("failed to get Coordinator RPC client: %w", err)
+		}
+	}
+
 	return nil
 }
 
@@ -199,7 +220,7 @@ func (n *OpNode) initL2(ctx context.Context, cfg *Config, snapshotLog log.Logger
 		return err
 	}
 
-	n.l2Driver = driver.NewDriver(&cfg.Driver, &cfg.Rollup, n.l2Source, n.l1Source, n, n, n.log, snapshotLog, n.metrics)
+	n.l2Driver = driver.NewDriver(&cfg.Driver, &cfg.Rollup, n.l2Source, n.l1Source, n, n.coordinatorClient, n, n.log, snapshotLog, n.metrics)
 
 	return nil
 }

--- a/op-node/node/server_test.go
+++ b/op-node/node/server_test.go
@@ -227,3 +227,7 @@ func (c *mockDriverClient) StartSequencer(ctx context.Context, blockHash common.
 func (c *mockDriverClient) StopSequencer(ctx context.Context) (common.Hash, error) {
 	return c.Mock.MethodCalled("StopSequencer").Get(0).(common.Hash), nil
 }
+
+func (c *mockDriverClient) SequencerStopped(ctx context.Context) bool {
+	return c.Mock.MethodCalled("SequencerStopped").Get(0).(bool)
+}

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 
+	"github.com/ethereum-optimism/optimism/op-node/client"
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
@@ -103,7 +104,7 @@ type AltSync interface {
 }
 
 // NewDriver composes an events handler that tracks L1 state, triggers L2 derivation, and optionally sequences new L2 blocks.
-func NewDriver(driverCfg *Config, cfg *rollup.Config, l2 L2Chain, l1 L1Chain, altSync AltSync, network Network, log log.Logger, snapshotLog log.Logger, metrics Metrics) *Driver {
+func NewDriver(driverCfg *Config, cfg *rollup.Config, l2 L2Chain, l1 L1Chain, altSync AltSync, coordinatorClient *client.CoordinatorClient, network Network, log log.Logger, snapshotLog log.Logger, metrics Metrics) *Driver {
 	l1 = NewMeteredL1Fetcher(l1, metrics)
 	l1State := NewL1State(log, metrics)
 	sequencerConfDepth := NewConfDepth(driverCfg.SequencerConfDepth, l1State.L1Head, l1)
@@ -113,7 +114,7 @@ func NewDriver(driverCfg *Config, cfg *rollup.Config, l2 L2Chain, l1 L1Chain, al
 	attrBuilder := derive.NewFetchingAttributesBuilder(cfg, l1, l2)
 	engine := derivationPipeline
 	meteredEngine := NewMeteredEngine(cfg, engine, metrics, log)
-	sequencer := NewSequencer(log, cfg, meteredEngine, attrBuilder, findL1Origin, metrics)
+	sequencer := NewSequencer(log, cfg, meteredEngine, coordinatorClient, attrBuilder, findL1Origin, metrics)
 
 	return &Driver{
 		l1State:          l1State,

--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -371,6 +371,10 @@ func (s *Driver) ResetDerivationPipeline(ctx context.Context) error {
 	}
 }
 
+func (s *Driver) SequencerStopped(_ctx context.Context) bool {
+	return s.driverConfig.SequencerStopped
+}
+
 func (s *Driver) StartSequencer(ctx context.Context, blockHash common.Hash) error {
 	if !s.driverConfig.SequencerEnabled {
 		return errors.New("sequencer is not enabled")

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -56,13 +56,15 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*node.Config, error) {
 	}
 
 	l2SyncEndpoint := NewL2SyncEndpointConfig(ctx)
+	coordinator := NewCoordinatorConfig(ctx)
 
 	cfg := &node.Config{
-		L1:     l1Endpoint,
-		L2:     l2Endpoint,
-		L2Sync: l2SyncEndpoint,
-		Rollup: *rollupConfig,
-		Driver: *driverConfig,
+		L1:          l1Endpoint,
+		L2:          l2Endpoint,
+		L2Sync:      l2SyncEndpoint,
+		Coordinator: *coordinator,
+		Rollup:      *rollupConfig,
+		Driver:      *driverConfig,
 		RPC: node.RPCConfig{
 			ListenAddr:  ctx.GlobalString(flags.RPCListenAddr.Name),
 			ListenPort:  ctx.GlobalInt(flags.RPCListenPort.Name),
@@ -140,6 +142,14 @@ func NewL2SyncEndpointConfig(ctx *cli.Context) *node.L2SyncEndpointConfig {
 	return &node.L2SyncEndpointConfig{
 		L2NodeAddr: ctx.GlobalString(flags.BackupL2UnsafeSyncRPC.Name),
 		TrustRPC:   ctx.GlobalBool(flags.BackupL2UnsafeSyncRPCTrustRPC.Name),
+	}
+}
+
+func NewCoordinatorConfig(ctx *cli.Context) *node.CoordinatorConfig {
+	return &node.CoordinatorConfig{
+		Enabled:         ctx.GlobalBool(flags.CoordinatorEnabledFlag.Name),
+		CoordinatorAddr: ctx.GlobalString(flags.CoordinatorAddrFlag.Name),
+		SequencerId:     ctx.GlobalString(flags.CoordinatorSequencerIdFlag.Name),
 	}
 }
 


### PR DESCRIPTION
The Optimism sequencer is single-entity and the current implementation does not include a fail-over mechanism. Which means that the current Optimism sequencer is a single point of failure. If it goes down, the whole optimistic rollup stops producing blocks.

External Coordinator comes to prevent this from happening, it ensures that only one instance of Optimism sequencer is producing and if it goes down, it will be replaced by another instance.

This PR adds support for optional external coordinator mode, by providing the following flags,

```
   --coordinator.enabled                       Enable the external coordinator mode [$OP_NODE_COORDINATOR_ENABLED]
   --coordinator.addr value                    Coordinator listening address [$OP_NODE_COORDINATOR_ADDR]
   --coordinator.sequencer-id value            the sequencer id configured in the Coordinator, used by Coordinator to distinguish different sequencers [$OP_NODE_COORDINATOR_SEQUENCER_ID]
```

e.g.

```
    --coordinator.enabled=true
    --coordinator.sequencer-id="seq0"
    --coordinator.addr="http://127.0.0.1:9762"
```

In order to produce new unsafe blocks, the sequencer must request building-block permission from the coordinator first.