### PR TITLE
op-node: Add `admin_sequencerActive` RPC method

### DIFF
--- a/op-e2e/actions/l2_verifier.go
+++ b/op-e2e/actions/l2_verifier.go
@@ -121,6 +121,10 @@ func (s *l2VerifierBackend) StopSequencer(ctx context.Context) (common.Hash, err
 	return common.Hash{}, errors.New("stopping the L2Verifier sequencer is not supported")
 }
 
+func (s *l2VerifierBackend) SequencerActive(ctx context.Context) (bool, error) {
+	return false, nil
+}
+
 func (s *L2Verifier) L2Finalized() eth.L2BlockRef {
 	return s.derivation.Finalized()
 }

--- a/op-e2e/system_adminrpc_test.go
+++ b/op-e2e/system_adminrpc_test.go
@@ -1,0 +1,177 @@
+package op_e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-node/client"
+	"github.com/ethereum-optimism/optimism/op-node/node"
+	"github.com/ethereum-optimism/optimism/op-node/sources"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStopStartSequencer(t *testing.T) {
+	InitParallel(t)
+
+	cfg := DefaultSystemConfig(t)
+	sys, err := cfg.Start()
+	require.Nil(t, err, "Error starting up system")
+	defer sys.Close()
+
+	l2Seq := sys.Clients["sequencer"]
+	rollupNode := sys.RollupNodes["sequencer"]
+
+	nodeRPC, err := rpc.DialContext(context.Background(), rollupNode.HTTPEndpoint())
+	require.Nil(t, err, "Error dialing node")
+	rollupClient := sources.NewRollupClient(client.NewBaseRPCClient(nodeRPC))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	active, err := rollupClient.SequencerActive(ctx)
+	require.NoError(t, err)
+	require.True(t, active, "sequencer should be active")
+
+	blockBefore := latestBlock(t, l2Seq)
+	time.Sleep(time.Duration(cfg.DeployConfig.L2BlockTime+1) * time.Second)
+	blockAfter := latestBlock(t, l2Seq)
+	require.Greaterf(t, blockAfter, blockBefore, "Chain did not advance")
+
+	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	blockHash, err := rollupClient.StopSequencer(ctx)
+	require.Nil(t, err, "Error stopping sequencer")
+
+	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	active, err = rollupClient.SequencerActive(ctx)
+	require.NoError(t, err)
+	require.False(t, active, "sequencer should be inactive")
+
+	blockBefore = latestBlock(t, l2Seq)
+	time.Sleep(time.Duration(cfg.DeployConfig.L2BlockTime+1) * time.Second)
+	blockAfter = latestBlock(t, l2Seq)
+	require.Equal(t, blockAfter, blockBefore, "Chain advanced after stopping sequencer")
+
+	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err = rollupClient.StartSequencer(ctx, blockHash)
+	require.Nil(t, err, "Error starting sequencer")
+
+	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	active, err = rollupClient.SequencerActive(ctx)
+	require.NoError(t, err)
+	require.True(t, active, "sequencer should be active again")
+
+	blockBefore = latestBlock(t, l2Seq)
+	time.Sleep(time.Duration(cfg.DeployConfig.L2BlockTime+1) * time.Second)
+	blockAfter = latestBlock(t, l2Seq)
+	require.Greater(t, blockAfter, blockBefore, "Chain did not advance after starting sequencer")
+}
+
+func TestPersistSequencerStateWhenChanged(t *testing.T) {
+	InitParallel(t)
+	ctx := context.Background()
+	dir := t.TempDir()
+	stateFile := dir + "/state.json"
+
+	cfg := DefaultSystemConfig(t)
+	// We don't need a verifier - just the sequencer is enough
+	delete(cfg.Nodes, "verifier")
+	cfg.Nodes["sequencer"].ConfigPersistence = node.NewConfigPersistence(stateFile)
+
+	sys, err := cfg.Start()
+	require.NoError(t, err)
+	defer sys.Close()
+
+	assertPersistedSequencerState(t, stateFile, node.StateStarted)
+
+	rollupRPCClient, err := rpc.DialContext(ctx, sys.RollupNodes["sequencer"].HTTPEndpoint())
+	require.Nil(t, err)
+	rollupClient := sources.NewRollupClient(client.NewBaseRPCClient(rollupRPCClient))
+
+	err = rollupClient.StartSequencer(ctx, common.Hash{0xaa})
+	require.ErrorContains(t, err, "sequencer already running")
+
+	head, err := rollupClient.StopSequencer(ctx)
+	require.NoError(t, err)
+	require.NotEqual(t, common.Hash{}, head)
+	assertPersistedSequencerState(t, stateFile, node.StateStopped)
+}
+
+func TestLoadSequencerStateOnStarted_Stopped(t *testing.T) {
+	InitParallel(t)
+	ctx := context.Background()
+	dir := t.TempDir()
+	stateFile := dir + "/state.json"
+
+	// Prepare the persisted state file with sequencer stopped
+	configReader := node.NewConfigPersistence(stateFile)
+	require.NoError(t, configReader.SequencerStopped())
+
+	cfg := DefaultSystemConfig(t)
+	// We don't need a verifier - just the sequencer is enough
+	delete(cfg.Nodes, "verifier")
+	seqCfg := cfg.Nodes["sequencer"]
+	seqCfg.ConfigPersistence = node.NewConfigPersistence(stateFile)
+
+	sys, err := cfg.Start()
+	require.NoError(t, err)
+	defer sys.Close()
+
+	rollupRPCClient, err := rpc.DialContext(ctx, sys.RollupNodes["sequencer"].HTTPEndpoint())
+	require.Nil(t, err)
+	rollupClient := sources.NewRollupClient(client.NewBaseRPCClient(rollupRPCClient))
+
+	// Still persisted as stopped after startup
+	assertPersistedSequencerState(t, stateFile, node.StateStopped)
+
+	// Sequencer is really stopped
+	_, err = rollupClient.StopSequencer(ctx)
+	require.ErrorContains(t, err, "sequencer not running")
+	assertPersistedSequencerState(t, stateFile, node.StateStopped)
+}
+
+func TestLoadSequencerStateOnStarted_Started(t *testing.T) {
+	InitParallel(t)
+	ctx := context.Background()
+	dir := t.TempDir()
+	stateFile := dir + "/state.json"
+
+	// Prepare the persisted state file with sequencer stopped
+	configReader := node.NewConfigPersistence(stateFile)
+	require.NoError(t, configReader.SequencerStarted())
+
+	cfg := DefaultSystemConfig(t)
+	// We don't need a verifier - just the sequencer is enough
+	delete(cfg.Nodes, "verifier")
+	seqCfg := cfg.Nodes["sequencer"]
+	seqCfg.Driver.SequencerStopped = true
+	seqCfg.ConfigPersistence = node.NewConfigPersistence(stateFile)
+
+	sys, err := cfg.Start()
+	require.NoError(t, err)
+	defer sys.Close()
+
+	rollupRPCClient, err := rpc.DialContext(ctx, sys.RollupNodes["sequencer"].HTTPEndpoint())
+	require.Nil(t, err)
+	rollupClient := sources.NewRollupClient(client.NewBaseRPCClient(rollupRPCClient))
+
+	// Still persisted as stopped after startup
+	assertPersistedSequencerState(t, stateFile, node.StateStarted)
+
+	// Sequencer is really stopped
+	err = rollupClient.StartSequencer(ctx, common.Hash{})
+	require.ErrorContains(t, err, "sequencer already running")
+	assertPersistedSequencerState(t, stateFile, node.StateStarted)
+}
+
+func assertPersistedSequencerState(t *testing.T, stateFile string, expected node.RunningState) {
+	configReader := node.NewConfigPersistence(stateFile)
+	state, err := configReader.SequencerState()
+	require.NoError(t, err)
+	require.Equalf(t, expected, state, "expected sequencer state %v but was %v", expected, state)
+}

--- a/op-node/node/api.go
+++ b/op-node/node/api.go
@@ -28,6 +28,7 @@ type driverClient interface {
 	ResetDerivationPipeline(context.Context) error
 	StartSequencer(ctx context.Context, blockHash common.Hash) error
 	StopSequencer(context.Context) (common.Hash, error)
+	SequencerActive(context.Context) (bool, error)
 }
 
 type rpcMetrics interface {
@@ -63,6 +64,12 @@ func (n *adminAPI) StopSequencer(ctx context.Context) (common.Hash, error) {
 	recordDur := n.m.RecordRPCServerRequest("admin_stopSequencer")
 	defer recordDur()
 	return n.dr.StopSequencer(ctx)
+}
+
+func (n *adminAPI) SequencerActive(ctx context.Context) (bool, error) {
+	recordDur := n.m.RecordRPCServerRequest("admin_sequencerActive")
+	defer recordDur()
+	return n.dr.SequencerActive(ctx)
 }
 
 type nodeAPI struct {

--- a/op-node/node/server_test.go
+++ b/op-node/node/server_test.go
@@ -227,3 +227,7 @@ func (c *mockDriverClient) StartSequencer(ctx context.Context, blockHash common.
 func (c *mockDriverClient) StopSequencer(ctx context.Context) (common.Hash, error) {
 	return c.Mock.MethodCalled("StopSequencer").Get(0).(common.Hash), nil
 }
+
+func (c *mockDriverClient) SequencerActive(ctx context.Context) (bool, error) {
+	return c.Mock.MethodCalled("SequencerActive").Get(0).(bool), nil
+}

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -122,6 +122,7 @@ func NewDriver(driverCfg *Config, cfg *rollup.Config, l2 L2Chain, l1 L1Chain, al
 		forceReset:       make(chan chan struct{}, 10),
 		startSequencer:   make(chan hashAndErrorChannel, 10),
 		stopSequencer:    make(chan chan hashAndError, 10),
+		sequencerActive:  make(chan chan bool, 10),
 		config:           cfg,
 		driverConfig:     driverCfg,
 		done:             make(chan struct{}),

--- a/op-node/sources/rollupclient.go
+++ b/op-node/sources/rollupclient.go
@@ -3,6 +3,7 @@ package sources
 import (
 	"context"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 
 	"github.com/ethereum-optimism/optimism/op-node/client"
@@ -40,4 +41,20 @@ func (r *RollupClient) Version(ctx context.Context) (string, error) {
 	var output string
 	err := r.rpc.CallContext(ctx, &output, "optimism_version")
 	return output, err
+}
+
+func (r *RollupClient) StartSequencer(ctx context.Context, unsafeHead common.Hash) error {
+	return r.rpc.CallContext(ctx, nil, "admin_startSequencer", unsafeHead)
+}
+
+func (r *RollupClient) StopSequencer(ctx context.Context) (common.Hash, error) {
+	var result common.Hash
+	err := r.rpc.CallContext(ctx, &result, "admin_stopSequencer")
+	return result, err
+}
+
+func (r *RollupClient) SequencerActive(ctx context.Context) (bool, error) {
+	var result bool
+	err := r.rpc.CallContext(ctx, &result, "admin_sequencerActive")
+	return result, err
 }


### PR DESCRIPTION
Cherry-pick [ef9c2090beaf66f89156ebea8dd3a2bff4de6de8](https://github.com/ethereum-optimism/optimism/pull/6190/commits/ef9c2090beaf66f89156ebea8dd3a2bff4de6de8).

This PR adds `admin_sequencerActive` RPC method.