### PR TITLE
feat(op-node): receiptsFetchingJob concurrent fetch

### DIFF
--- a/op-node/sources/receipts.go
+++ b/op-node/sources/receipts.go
@@ -341,18 +341,19 @@ type receiptsFetchingJob struct {
 
 	fetcher *IterativeBatchCall[common.Hash, *types.Receipt]
 
-	result types.Receipts
+	result                types.Receipts
+	maxConcurrentRequests int
 }
 
-func NewReceiptsFetchingJob(requester ReceiptsRequester, client rpcClient, maxBatchSize int, block eth.BlockID,
-	receiptHash common.Hash, txHashes []common.Hash) *receiptsFetchingJob {
+func NewReceiptsFetchingJob(requester ReceiptsRequester, client rpcClient, maxBatchSize int, block eth.BlockID, receiptHash common.Hash, txHashes []common.Hash, maxConcurrentRequests int) *receiptsFetchingJob {
 	return &receiptsFetchingJob{
-		requester:    requester,
-		client:       client,
-		maxBatchSize: maxBatchSize,
-		block:        block,
-		receiptHash:  receiptHash,
-		txHashes:     txHashes,
+		requester:             requester,
+		client:                client,
+		maxBatchSize:          maxBatchSize,
+		block:                 block,
+		receiptHash:           receiptHash,
+		txHashes:              txHashes,
+		maxConcurrentRequests: maxConcurrentRequests,
 	}
 }
 
@@ -377,13 +378,30 @@ func (job *receiptsFetchingJob) runFetcher(ctx context.Context) error {
 		)
 	}
 	// Fetch all receipts
-	for {
-		if err := job.fetcher.Fetch(ctx); err == io.EOF {
-			break
-		} else if err != nil {
-			return err
+	var wg sync.WaitGroup
+	concurrentRequests := job.maxConcurrentRequests
+	wg.Add(concurrentRequests)
+	errs := make(chan error, concurrentRequests)
+	for i := 0; i < concurrentRequests; i++ {
+		go func() {
+			defer wg.Done()
+			for {
+				if err := job.fetcher.Fetch(ctx); err == io.EOF {
+					return
+				} else if err != nil {
+					errs <- err
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	if len(errs) > 0 {
+		if callErr := <-errs; callErr != nil {
+			return callErr
 		}
 	}
+
 	result, err := job.fetcher.Result()
 	if err != nil { // errors if results are not available yet, should never happen.
 		return err


### PR DESCRIPTION
The current logic of receiptsFetchingJob is a serial fetch, modifying it to a concurrent fetch can significantly improve performance