### PR TITLE
feat: check channel timed out before data submission

### DIFF
--- a/op-batcher/batcher/channel_manager_test.go
+++ b/op-batcher/batcher/channel_manager_test.go
@@ -125,7 +125,7 @@ func TestChannelManagerNextTxData(t *testing.T) {
 	m := NewChannelManager(log, metrics.NoopMetrics, ChannelConfig{})
 
 	// Nil pending channel should return EOF
-	returnedTxData, err := m.nextTxData()
+	returnedTxData, err := m.nextTxData(eth.BlockID{})
 	require.ErrorIs(t, err, io.EOF)
 	require.Equal(t, txData{}, returnedTxData)
 
@@ -133,7 +133,7 @@ func TestChannelManagerNextTxData(t *testing.T) {
 	// The nextTxData function should still return EOF
 	// since the pending channel has no frames
 	require.NoError(t, m.ensurePendingChannel(eth.BlockID{}))
-	returnedTxData, err = m.nextTxData()
+	returnedTxData, err = m.nextTxData(eth.BlockID{})
 	require.ErrorIs(t, err, io.EOF)
 	require.Equal(t, txData{}, returnedTxData)
 
@@ -150,7 +150,7 @@ func TestChannelManagerNextTxData(t *testing.T) {
 	require.Equal(t, 1, m.pendingChannel.NumFrames())
 
 	// Now the nextTxData function should return the frame
-	returnedTxData, err = m.nextTxData()
+	returnedTxData, err = m.nextTxData(eth.BlockID{})
 	expectedTxData := txData{frame}
 	expectedChannelID := expectedTxData.ID()
 	require.NoError(t, err)
@@ -209,7 +209,7 @@ func TestChannelManager_Clear(t *testing.T) {
 	require.NoError(m.processBlocks())
 	require.NoError(m.pendingChannel.co.Flush())
 	require.NoError(m.pendingChannel.OutputFrames())
-	_, err := m.nextTxData()
+	_, err := m.nextTxData(l1BlockID)
 	require.NoError(err)
 	require.Len(m.blocks, 0)
 	require.Equal(newL1Tip, m.tip)
@@ -260,7 +260,7 @@ func TestChannelManagerTxConfirmed(t *testing.T) {
 	}
 	m.pendingChannel.PushFrame(frame)
 	require.Equal(t, 1, m.pendingChannel.NumFrames())
-	returnedTxData, err := m.nextTxData()
+	returnedTxData, err := m.nextTxData(eth.BlockID{})
 	expectedTxData := txData{frame}
 	expectedChannelID := expectedTxData.ID()
 	require.NoError(t, err)
@@ -308,7 +308,7 @@ func TestChannelManagerTxFailed(t *testing.T) {
 	}
 	m.pendingChannel.PushFrame(frame)
 	require.Equal(t, 1, m.pendingChannel.NumFrames())
-	returnedTxData, err := m.nextTxData()
+	returnedTxData, err := m.nextTxData(eth.BlockID{})
 	expectedTxData := txData{frame}
 	expectedChannelID := expectedTxData.ID()
 	require.NoError(t, err)


### PR DESCRIPTION
### Specification

Previously, _Batcher_ would check the _channel timeout_ after confirming a transaction.

Now this PR also checks the _channel timeout_ before sending a transaction.

If there are pending channel frames that have not yet been submitted and the current l1Head exceeds the channel timeout, it is advisable to cancel the pending channel to prevent unnecessary submission.

By canceling the pending channel, its blocks will be re-pushed back to the pending blocks queue. And later, the Batcher will make attempt to construct a new channel.

### Rational

Check _channel timeout_ before sending transactions to **reduce the probability of on-chain _channel timeout_**.

### Context for reproducing issue

1. Construct a multi-frames channel.
2. Submit certain frames of this channel.
3. Batcher has insufficient balance for the submission of the remaining frames.
4. `wait(channel_timeout)`
5. Fund some balance to Batcher. Batcher re-submits the remaining frames.
6. On-chain _channel timeout_ occurs

### Review suggestion

This additional check is not required if we can guarantee sufficient balance

The probability is very low.

**My personal opinion would be to close this PR.**