### PR TITLE
perf: reduce quarantine eviction

### DIFF
--- a/op-node/p2p/sync.go
+++ b/op-node/p2p/sync.go
@@ -251,7 +251,7 @@ func NewSyncClient(log log.Logger, cfg *rollup.Config, newStream newStreamFn, rc
 	// never errors with positive LRU cache size
 	// TODO(CLI-3733): if we had an LRU based on on total payloads size, instead of payload count,
 	//  we can safely buffer more data in the happy case.
-	q, _ := simplelru.NewLRU[common.Hash, syncResult](100, c.onQuarantineEvict)
+	q, _ := simplelru.NewLRU[common.Hash, syncResult](3600, c.onQuarantineEvict)
 	c.quarantine = q
 	trusted, _ := simplelru.NewLRU[common.Hash, struct{}](10000, nil)
 	c.trusted = trusted


### PR DESCRIPTION
The Req-Resp protocol is primarily employed to synchronize recent blocks that have not yet been submitted to L1.

Given that the _channel timeout_ on the mainnet is set to `1200`, and considering the L1 block interval of 3 seconds, the _channel timeout_ can effectively be regarded as a timeframe of 3600s.

As a result, I have configured the capacity of the `quarantine` to be `3600`, which can help mitigate the probability of eviction from the quarantine, so that to speed up the sync process.

----

Weakness of current Req-Resp implementation:
1. Trust chain must proceed from back to front   ←   Only Gossip blocks carry with sequencer's signature
2. During one round of `RequestL2Range`, for each number, alt-sync only requests to single peer
3. Lacks of re-try for request failures. Alt-sync will continue request for other blocks.
4. `quarantine`, the orphan block cache, a LRU cache, has size limit to `100`. It will evict old blocks when becomes full.
5. _Peer rate limit_ is 4 requests per second

This PR seeks to improve the 4th issue. It will speed up the Req-Resp process.


---

### Context

1. Increase Batcher submission interval to 10 minutes, `OP_BATCHER_MAX_CHANNEL_DURATION = 600`

2. Stop two validator nodes

3. Wait for 5 minutes

4. Start the above two nodes using different versions

5. Compare both nodes' sync times