### PR TITLE
chore: add mainnet assets for running nodes

### DIFF
--- a/assets/mainnet/rollup.json
+++ b/assets/mainnet/rollup.json
@@ -1,0 +1,29 @@
+{
+  "genesis": {
+    "l1": {
+      "hash": "0x29443b21507894febe7700f7c5cd3569cc8bf1ba535df0489276d8004af81044",
+      "number": 30758357
+    },
+    "l2": {
+      "hash": "0x4dd61178c8b0f01670c231597e7bcb368e84545acd46d940a896d6a791dd6df4",
+      "number": 0
+    },
+    "l2_time": 1691753723,
+    "system_config": {
+      "batcherAddr": "0xef8783382ef80ec23b66c43575a6103deca909c3",
+      "overhead": "0x0000000000000000000000000000000000000000000000000000000000000834",
+      "scalar": "0x00000000000000000000000000000000000000000000000000000000000f4240",
+      "gasLimit": 100000000
+    }
+  },
+  "block_time": 1,
+  "max_sequencer_drift": 600,
+  "seq_window_size": 14400,
+  "channel_timeout": 1200,
+  "l1_chain_id": 56,
+  "l2_chain_id": 204,
+  "regolith_time": 0,
+  "batch_inbox_address": "0xff00000000000000000000000000000000000204",
+  "deposit_contract_address": "0x1876ea7702c0ad0c6a2ae6036de7733edfbca519",
+  "l1_system_config_address": "0x7ac836148c14c74086d57f7828f2d065672db3b8"
+}


### PR DESCRIPTION

The Mainnet assets for running full nodes.

Check the [doc](https://docs.bnbchain.org/opbnb-docs/docs/tutorials/running-a-mainnet-node) for the detailed guide.