### PR TITLE
fix(op-node): l1 client use eth_getFinalizedBlock to get finalized block

### DIFF
--- a/op-node/sources/eth_client.go
+++ b/op-node/sources/eth_client.go
@@ -307,6 +307,14 @@ func (s *EthClient) InfoByLabel(ctx context.Context, label eth.BlockLabel) (eth.
 	return s.headerCall(ctx, "eth_getBlockByNumber", label)
 }
 
+func (s *EthClient) BSCInfoByLabel(ctx context.Context, label eth.BlockLabel) (eth.BlockInfo, error) {
+	// can't hit the cache when querying the head due to reorgs / changes.
+	if label == eth.Finalized {
+		return s.headerCall(ctx, "eth_getFinalizedBlock", numberID(15))
+	}
+	return s.headerCall(ctx, "eth_getBlockByNumber", label)
+}
+
 func (s *EthClient) InfoAndTxsByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, types.Transactions, error) {
 	if header, ok := s.headersCache.Get(hash); ok {
 		if txs, ok := s.transactionsCache.Get(hash); ok {

--- a/op-node/sources/l1_client.go
+++ b/op-node/sources/l1_client.go
@@ -75,7 +75,7 @@ func NewL1Client(client client.RPC, log log.Logger, metrics caching.Metrics, con
 // L1BlockRefByLabel returns the [eth.L1BlockRef] for the given block label.
 // Notice, we cannot cache a block reference by label because labels are not guaranteed to be unique.
 func (s *L1Client) L1BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L1BlockRef, error) {
-	info, err := s.InfoByLabel(ctx, label)
+	info, err := s.BSCInfoByLabel(ctx, label)
 	if err != nil {
 		// Both geth and erigon like to serve non-standard errors for the safe and finalized heads, correct that.
 		// This happens when the chain just started and nothing is marked as safe/finalized yet.


### PR DESCRIPTION
There are two methods to get finalized block on BSC:
1. eth_getBLockByNumber with finalized tag
2. eth_getFinalizedBlock

This PR changes l1Client to use second method instead of first one, due to first method only return the fastFinalizedHeader, which is not the exact finalized block when fast finalize failed