### PR TITLE
bugfix(op-node): fix the issue of inaccurate peerCount Metric

### DIFF
--- a/op-node/metrics/metrics.go
+++ b/op-node/metrics/metrics.go
@@ -59,6 +59,7 @@ type Metricer interface {
 	RecordGossipEvent(evType int32)
 	IncPeerCount()
 	DecPeerCount()
+	SetPeerCount(peerCount int)
 	IncStreamCount()
 	DecStreamCount()
 	RecordBandwidth(ctx context.Context, bwc *libp2pmetrics.BandwidthCounter)
@@ -608,6 +609,10 @@ func (m *Metrics) DecPeerCount() {
 	m.PeerCount.Dec()
 }
 
+func (m *Metrics) SetPeerCount(peerCount int) {
+	m.PeerCount.Set(float64(peerCount))
+}
+
 func (m *Metrics) IncStreamCount() {
 	m.StreamCount.Inc()
 }
@@ -793,6 +798,9 @@ func (n *noopMetricer) IncPeerCount() {
 }
 
 func (n *noopMetricer) DecPeerCount() {
+}
+
+func (n *noopMetricer) SetPeerCount(peerCount int) {
 }
 
 func (n *noopMetricer) IncStreamCount() {

--- a/op-node/p2p/notifications.go
+++ b/op-node/p2p/notifications.go
@@ -12,6 +12,7 @@ import (
 type NotificationsMetricer interface {
 	IncPeerCount()
 	DecPeerCount()
+	SetPeerCount(peerCount int)
 	IncStreamCount()
 	DecStreamCount()
 }
@@ -28,12 +29,14 @@ func (notif *notifications) ListenClose(n network.Network, a ma.Multiaddr) {
 	notif.log.Info("stopped listening network address", "addr", a)
 }
 func (notif *notifications) Connected(n network.Network, v network.Conn) {
-	notif.m.IncPeerCount()
-	notif.log.Info("connected to peer", "peer", v.RemotePeer(), "addr", v.RemoteMultiaddr())
+	currentPeerCount := len(n.Peers())
+	notif.m.SetPeerCount(currentPeerCount)
+	notif.log.Info("connected to peer", "peer", v.RemotePeer(), "addr", v.RemoteMultiaddr(), "peerCount", currentPeerCount)
 }
 func (notif *notifications) Disconnected(n network.Network, v network.Conn) {
-	notif.m.DecPeerCount()
-	notif.log.Info("disconnected from peer", "peer", v.RemotePeer(), "addr", v.RemoteMultiaddr())
+	currentPeerCount := len(n.Peers())
+	notif.m.SetPeerCount(currentPeerCount)
+	notif.log.Info("disconnected from peer", "peer", v.RemotePeer(), "addr", v.RemoteMultiaddr(), "peerCount", currentPeerCount)
 }
 func (notif *notifications) OpenedStream(n network.Network, v network.Stream) {
 	notif.m.IncStreamCount()


### PR DESCRIPTION
# Background

When we use DNS to specify the addresses of staticPeers, there may be a situation where one peer corresponds to multiple connections. Therefore, the same peer may trigger the `Connected` or the `Disconnected` event of `Notifiee` multiple times. This will cause inaccurate peerCount statistics. In addition, restarting the op-node service may also cause statistical problems. Because peerCount is a gauge type indicator, if the `Disconnected` event cannot be processed in time when the service is closed, peerCount may retain incorrect data and will not decrease to 0.

# Solution

In order to minimize the impact of duplicate events and server restarts, we should use `Gauge.Set(float64)` instead of the currently used `Inc*()` and `Dec*()` methods. Getting the length of the peers array stored in the `Network` object each time will make the statistical indicators more accurate.