### PR TITLE
bugfix(op-node): syncClient incorrectly removes peer issue

### DIFF
--- a/op-node/p2p/node.go
+++ b/op-node/p2p/node.go
@@ -97,7 +97,10 @@ func (n *NodeP2P) init(resourcesCtx context.Context, rollupCfg *rollup.Config, l
 					n.syncCl.AddPeer(conn.RemotePeer())
 				},
 				DisconnectedF: func(nw network.Network, conn network.Conn) {
-					n.syncCl.RemovePeer(conn.RemotePeer())
+					// only when no connection is available, we can remove the peer
+					if nw.Connectedness(conn.RemotePeer()) == network.NotConnected {
+						n.syncCl.RemovePeer(conn.RemotePeer())
+					}
 				},
 			})
 			n.syncCl.Start()

--- a/op-node/p2p/node.go
+++ b/op-node/p2p/node.go
@@ -107,17 +107,6 @@ func (n *NodeP2P) init(resourcesCtx context.Context, rollupCfg *rollup.Config, l
 					}
 				}
 			}()
-			n.host.Network().Notify(&network.NotifyBundle{
-				ConnectedF: func(nw network.Network, conn network.Conn) {
-					n.syncCl.AddPeer(conn.RemotePeer())
-				},
-				DisconnectedF: func(nw network.Network, conn network.Conn) {
-					// only when no connection is available, we can remove the peer
-					if nw.Connectedness(conn.RemotePeer()) == network.NotConnected {
-						n.syncCl.RemovePeer(conn.RemotePeer())
-					}
-				},
-			})
 			n.syncCl.Start()
 			// the host may already be connected to peers, add them all to the sync client
 			for _, peerID := range n.host.Network().Peers() {

--- a/op-node/p2p/node.go
+++ b/op-node/p2p/node.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/libp2p/go-libp2p/core/event"
 	"net"
 	"strconv"
 	"time"
@@ -93,20 +92,17 @@ func (n *NodeP2P) init(resourcesCtx context.Context, rollupCfg *rollup.Config, l
 		// Activate the P2P req-resp sync if enabled by feature-flag.
 		if setup.ReqRespSyncEnabled() {
 			n.syncCl = NewSyncClient(log, rollupCfg, n.host.NewStream, gossipIn.OnUnsafeL2Payload, metrics)
-			subscribe, err := n.host.EventBus().Subscribe(&event.EvtPeerConnectednessChanged{})
-			if err != nil {
-				return fmt.Errorf("failed to subscribe peer connectedness changed event: %w", err)
-			}
-			go func() {
-				for evt := range subscribe.Out() {
-					evto := evt.(event.EvtPeerConnectednessChanged)
-					if evto.Connectedness == network.Connected {
-						n.syncCl.AddPeer(evto.Peer)
-					} else if evto.Connectedness == network.NotConnected {
-						n.syncCl.RemovePeer(evto.Peer)
+			n.host.Network().Notify(&network.NotifyBundle{
+				ConnectedF: func(nw network.Network, conn network.Conn) {
+					n.syncCl.AddPeer(conn.RemotePeer())
+				},
+				DisconnectedF: func(nw network.Network, conn network.Conn) {
+					// only when no connection is available, we can remove the peer
+					if nw.Connectedness(conn.RemotePeer()) == network.NotConnected {
+						n.syncCl.RemovePeer(conn.RemotePeer())
 					}
-				}
-			}()
+				},
+			})
 			n.syncCl.Start()
 			// the host may already be connected to peers, add them all to the sync client
 			for _, peerID := range n.host.Network().Peers() {

--- a/op-node/p2p/node.go
+++ b/op-node/p2p/node.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/libp2p/go-libp2p/core/event"
 	"net"
 	"strconv"
 	"time"
@@ -92,6 +93,20 @@ func (n *NodeP2P) init(resourcesCtx context.Context, rollupCfg *rollup.Config, l
 		// Activate the P2P req-resp sync if enabled by feature-flag.
 		if setup.ReqRespSyncEnabled() {
 			n.syncCl = NewSyncClient(log, rollupCfg, n.host.NewStream, gossipIn.OnUnsafeL2Payload, metrics)
+			subscribe, err := n.host.EventBus().Subscribe(&event.EvtPeerConnectednessChanged{})
+			if err != nil {
+				return fmt.Errorf("failed to subscribe peer connectedness changed event: %w", err)
+			}
+			go func() {
+				for evt := range subscribe.Out() {
+					evto := evt.(event.EvtPeerConnectednessChanged)
+					if evto.Connectedness == network.Connected {
+						n.syncCl.AddPeer(evto.Peer)
+					} else if evto.Connectedness == network.NotConnected {
+						n.syncCl.RemovePeer(evto.Peer)
+					}
+				}
+			}()
 			n.host.Network().Notify(&network.NotifyBundle{
 				ConnectedF: func(nw network.Network, conn network.Conn) {
 					n.syncCl.AddPeer(conn.RemotePeer())


### PR DESCRIPTION
# Background

When the staticPeer is configured with a DNS address (such as `/dns/xxx.com/tcp/xxx/p2p/xxx`), a peer can obtain multiple IP addresses through domain name resolution. However, in Libp2p, dialing concurrently can result in one peer corresponding to multiple connections, which is exacerbated by multiple IP addresses. If one of the connections is disconnected due to an unstable network or other reasons, the `Notifiee.Disconnected` event is triggered. At this time, the peer is removed from the syncClient, and the processing flow of the peerLoop exits. The log displays the message `stopped syncing loop of peer`. However, the peer still has other connections that can be used for p2p synchronization. Therefore, we should not remove this peer unless we determine that all of its connections are disconnected and there are no available connections, just like the check performed by the `monitorStaticPeers` function.

# Solution

Add a condition to determine when to remove a peer from the syncClient: only remove the peer if it cannot establish a connection.