### PR TITLE
feat(op-node/op-batcher/op-proposer): add fallbackClient

### DIFF
--- a/op-batcher/batcher/config.go
+++ b/op-batcher/batcher/config.go
@@ -1,6 +1,7 @@
 package batcher
 
 import (
+	"github.com/ethereum-optimism/optimism/op-service/client"
 	"time"
 
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -22,7 +23,7 @@ import (
 type Config struct {
 	log        log.Logger
 	metr       metrics.Metricer
-	L1Client   *ethclient.Client
+	L1Client   client.EthClient
 	L2Client   *ethclient.Client
 	RollupNode *sources.RollupClient
 	TxManager  txmgr.TxManager

--- a/op-batcher/batcher/config.go
+++ b/op-batcher/batcher/config.go
@@ -1,8 +1,9 @@
 package batcher
 
 import (
-	"github.com/ethereum-optimism/optimism/op-service/client"
 	"time"
+
+	"github.com/ethereum-optimism/optimism/op-service/client"
 
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -50,7 +50,7 @@ func NewBatchSubmitterFromCLIConfig(cfg CLIConfig, l log.Logger, m metrics.Metri
 
 	// Connect to L1 and L2 providers. Perform these last since they are the
 	// most expensive.
-	l1Client, err := opclient.DialEthClientWithTimeoutAndFallback(ctx, cfg.L1EthRpc, opclient.DefaultDialTimeout, l, 10, m)
+	l1Client, err := opclient.DialEthClientWithTimeoutAndFallback(ctx, cfg.L1EthRpc, opclient.DefaultDialTimeout, l, opclient.BatcherFallbackThreshold, m)
 	if err != nil {
 		return nil, err
 	}

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -50,7 +50,7 @@ func NewBatchSubmitterFromCLIConfig(cfg CLIConfig, l log.Logger, m metrics.Metri
 
 	// Connect to L1 and L2 providers. Perform these last since they are the
 	// most expensive.
-	l1Client, err := opclient.DialEthClientWithTimeout(ctx, cfg.L1EthRpc, opclient.DefaultDialTimeout)
+	l1Client, err := opclient.DialEthClientWithTimeoutAndFallback(ctx, cfg.L1EthRpc, opclient.DefaultDialTimeout, l)
 	if err != nil {
 		return nil, err
 	}

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -50,7 +50,7 @@ func NewBatchSubmitterFromCLIConfig(cfg CLIConfig, l log.Logger, m metrics.Metri
 
 	// Connect to L1 and L2 providers. Perform these last since they are the
 	// most expensive.
-	l1Client, err := opclient.DialEthClientWithTimeoutAndFallback(ctx, cfg.L1EthRpc, opclient.DefaultDialTimeout, l)
+	l1Client, err := opclient.DialEthClientWithTimeoutAndFallback(ctx, cfg.L1EthRpc, opclient.DefaultDialTimeout, l, 10)
 	if err != nil {
 		return nil, err
 	}

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -50,7 +50,7 @@ func NewBatchSubmitterFromCLIConfig(cfg CLIConfig, l log.Logger, m metrics.Metri
 
 	// Connect to L1 and L2 providers. Perform these last since they are the
 	// most expensive.
-	l1Client, err := opclient.DialEthClientWithTimeoutAndFallback(ctx, cfg.L1EthRpc, opclient.DefaultDialTimeout, l, 10)
+	l1Client, err := opclient.DialEthClientWithTimeoutAndFallback(ctx, cfg.L1EthRpc, opclient.DefaultDialTimeout, l, 10, m)
 	if err != nil {
 		return nil, err
 	}

--- a/op-batcher/flags/flags.go
+++ b/op-batcher/flags/flags.go
@@ -22,7 +22,7 @@ var (
 	// Required flags
 	L1EthRpcFlag = cli.StringFlag{
 		Name:   "l1-eth-rpc",
-		Usage:  "HTTP provider URL for L1",
+		Usage:  "HTTP provider URL for L1. Multiple alternative addresses are supported, separated by commas, and the first address is used by default",
 		EnvVar: opservice.PrefixEnvVar(EnvVarPrefix, "L1_ETH_RPC"),
 	}
 	L2EthRpcFlag = cli.StringFlag{

--- a/op-batcher/metrics/metrics.go
+++ b/op-batcher/metrics/metrics.go
@@ -2,10 +2,10 @@ package metrics
 
 import (
 	"context"
+	"github.com/ethereum/go-ethereum"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -185,7 +185,7 @@ func (m *Metrics) Document() []opmetrics.DocumentedMetric {
 }
 
 func (m *Metrics) StartBalanceMetrics(ctx context.Context,
-	l log.Logger, client *ethclient.Client, account common.Address) {
+	l log.Logger, client ethereum.ChainStateReader, account common.Address) {
 	opmetrics.LaunchBalanceMetrics(ctx, l, m.registry, m.ns, client, account)
 }
 

--- a/op-batcher/metrics/metrics.go
+++ b/op-batcher/metrics/metrics.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"context"
+
 	"github.com/ethereum/go-ethereum"
 
 	"github.com/ethereum/go-ethereum/common"

--- a/op-batcher/metrics/noop.go
+++ b/op-batcher/metrics/noop.go
@@ -35,3 +35,6 @@ func (*noopMetrics) RecordChannelTimedOut(derive.ChannelID)       {}
 func (*noopMetrics) RecordBatchTxSubmitted() {}
 func (*noopMetrics) RecordBatchTxSuccess()   {}
 func (*noopMetrics) RecordBatchTxFailed()    {}
+
+func (m *noopMetrics) RecordL1UrlSwitchEvt(url string) {
+}

--- a/op-e2e/actions/fallback_client_test.go
+++ b/op-e2e/actions/fallback_client_test.go
@@ -54,8 +54,8 @@ func TestL1FallbackClient_SwitchUrl(gt *testing.T) {
 	}
 	dp := e2eutils.MakeDeployParams(t, p)
 	sd := e2eutils.Setup(t, dp, defaultAlloc)
-	log := testlog.Logger(t, log.LvlDebug)
-	miner, l1_2, _, engine, sequencer, fallbackClient := setupFallbackClientTest(t, sd, log, "http://127.0.0.1:8545,http://127.0.0.1:8546,http://127.0.0.1:8547")
+	logT := testlog.Logger(t, log.LvlDebug)
+	miner, l1_2, _, engine, sequencer, fallbackClient := setupFallbackClientTest(t, sd, logT, "http://127.0.0.1:8545,http://127.0.0.1:8546,http://127.0.0.1:8547")
 	miner.ActL1SetFeeRecipient(common.Address{'A'})
 
 	sequencer.ActL2PipelineFull(t)

--- a/op-e2e/actions/fallback_client_test.go
+++ b/op-e2e/actions/fallback_client_test.go
@@ -1,0 +1,120 @@
+package actions
+
+import (
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
+	"github.com/ethereum-optimism/optimism/op-node/client"
+	"github.com/ethereum-optimism/optimism/op-node/eth"
+	"github.com/ethereum-optimism/optimism/op-node/sources"
+	"github.com/ethereum-optimism/optimism/op-node/testlog"
+	service_client "github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/stretchr/testify/require"
+	"math/big"
+	"testing"
+	"time"
+)
+
+func setupFallbackClientTest(t Testing, sd *e2eutils.SetupData, log log.Logger, l1Url string) (*L1Miner, *L1Replica, *L1Replica, *L2Engine, *L2Sequencer, *sources.FallbackClient) {
+	jwtPath := e2eutils.WriteDefaultJWT(t)
+
+	miner := NewL1MinerWithPort(t, log, sd.L1Cfg, 8545)
+	l1_2 := NewL1ReplicaWithPort(t, log, sd.L1Cfg, 8546)
+	l1_3 := NewL1ReplicaWithPort(t, log, sd.L1Cfg, 8547)
+	isMultiUrl, urlList := service_client.MultiUrlParse(l1Url)
+	require.True(t, isMultiUrl)
+	opts := []client.RPCOption{
+		client.WithHttpPollInterval(0),
+		client.WithDialBackoff(10),
+	}
+	rpc, err := client.NewRPC(t.Ctx(), log, urlList[0], opts...)
+	require.NoError(t, err)
+	fallbackClient := sources.NewFallbackClient(t.Ctx(), rpc, urlList, log, sd.RollupCfg.L1ChainID, sd.RollupCfg.Genesis.L1, func(url string) (client.RPC, error) {
+		return client.NewRPC(t.Ctx(), log, url, opts...)
+	})
+	l1F, err := sources.NewL1Client(fallbackClient, log, nil, sources.L1ClientDefaultConfig(sd.RollupCfg, false, sources.RPCKindBasic))
+	require.NoError(t, err)
+	engine := NewL2Engine(t, log, sd.L2Cfg, sd.RollupCfg.Genesis.L1, jwtPath)
+	l2Cl, err := sources.NewEngineClient(engine.RPCClient(), log, nil, sources.EngineClientDefaultConfig(sd.RollupCfg))
+	require.NoError(t, err)
+
+	sequencer := NewL2Sequencer(t, log, l1F, l2Cl, sd.RollupCfg, 0)
+	return miner, l1_2, l1_3, engine, sequencer, fallbackClient.(*sources.FallbackClient)
+}
+
+func TestL1FallbackClient_SwitchUrl(gt *testing.T) {
+	t := NewDefaultTesting(gt)
+	p := &e2eutils.TestParams{
+		MaxSequencerDrift:   300,
+		SequencerWindowSize: 200,
+		ChannelTimeout:      120,
+		L1BlockTime:         12,
+	}
+	dp := e2eutils.MakeDeployParams(t, p)
+	sd := e2eutils.Setup(t, dp, defaultAlloc)
+	log := testlog.Logger(t, log.LvlDebug)
+	miner, l1_2, _, engine, sequencer, fallbackClient := setupFallbackClientTest(t, sd, log, "http://127.0.0.1:8545,http://127.0.0.1:8546,http://127.0.0.1:8547")
+	miner.ActL1SetFeeRecipient(common.Address{'A'})
+
+	sequencer.ActL2PipelineFull(t)
+
+	signer := types.LatestSigner(sd.L2Cfg.Config)
+	cl := engine.EthClient()
+	aliceTx := func() {
+		n, err := cl.PendingNonceAt(t.Ctx(), dp.Addresses.Alice)
+		require.NoError(t, err)
+		tx := types.MustSignNewTx(dp.Secrets.Alice, signer, &types.DynamicFeeTx{
+			ChainID:   sd.L2Cfg.Config.ChainID,
+			Nonce:     n,
+			GasTipCap: big.NewInt(2 * params.GWei),
+			GasFeeCap: new(big.Int).Add(miner.l1Chain.CurrentBlock().BaseFee, big.NewInt(2*params.GWei)),
+			Gas:       params.TxGas,
+			To:        &dp.Addresses.Bob,
+			Value:     e2eutils.Ether(2),
+		})
+		require.NoError(gt, cl.SendTransaction(t.Ctx(), tx))
+	}
+	makeL2BlockWithAliceTx := func() {
+		aliceTx()
+		sequencer.ActL2StartBlock(t)
+		engine.ActL2IncludeTx(dp.Addresses.Alice)(t) // include a test tx from alice
+		sequencer.ActL2EndBlock(t)
+	}
+
+	errRpc := miner.RPCClient().CallContext(t.Ctx(), nil, "admin_stopHTTP")
+	require.NoError(t, errRpc)
+
+	l2BlockCount := 0
+	for i := 0; i < 4 && l2BlockCount <= 20; i++ {
+		miner.ActL1StartBlock(12)(t)
+		miner.ActL1EndBlock(t)
+		newBlock := miner.l1Chain.GetBlockByHash(miner.l1Chain.CurrentBlock().Hash())
+		_, err := l1_2.l1Chain.InsertChain([]*types.Block{newBlock})
+		require.NoError(t, err)
+
+		sequencer.L2Verifier.l1State.HandleNewL1HeadBlock(eth.L1BlockRef{
+			Hash:       newBlock.Hash(),
+			Number:     newBlock.NumberU64(),
+			ParentHash: newBlock.ParentHash(),
+			Time:       newBlock.Time(),
+		})
+		origin := miner.l1Chain.CurrentBlock()
+
+		for sequencer.SyncStatus().UnsafeL2.Time+sd.RollupCfg.BlockTime < origin.Time {
+			makeL2BlockWithAliceTx()
+			//require.Equal(t, uint64(i), sequencer.SyncStatus().UnsafeL2.L1Origin.Number, "no L1 origin change before time matches")
+			l2BlockCount++
+			if l2BlockCount == 12 {
+				require.Equal(t, 1, fallbackClient.GetCurrentIndex(), "fallback client should switch url to second url")
+				errRpc2 := miner.RPCClient().CallContext(t.Ctx(), nil, "admin_startHTTP", "127.0.0.1", 8545, "*", "eth,net,web3,debug,admin,txpool", "*")
+				require.NoError(t, errRpc2)
+			}
+			if l2BlockCount == 20 {
+				require.Equal(t, 0, fallbackClient.GetCurrentIndex(), "fallback client should recover url to first url")
+			}
+			time.Sleep(1 * time.Second)
+		}
+	}
+}

--- a/op-e2e/actions/fallback_client_test.go
+++ b/op-e2e/actions/fallback_client_test.go
@@ -87,7 +87,7 @@ func TestL1FallbackClient_SwitchUrl(gt *testing.T) {
 	require.NoError(t, errRpc)
 
 	l2BlockCount := 0
-	for i := 0; i < 4 && l2BlockCount <= 20; i++ {
+	for i := 0; i < 6; i++ {
 		miner.ActL1StartBlock(12)(t)
 		miner.ActL1EndBlock(t)
 		newBlock := miner.l1Chain.GetBlockByHash(miner.l1Chain.CurrentBlock().Hash())
@@ -106,15 +106,15 @@ func TestL1FallbackClient_SwitchUrl(gt *testing.T) {
 			makeL2BlockWithAliceTx()
 			//require.Equal(t, uint64(i), sequencer.SyncStatus().UnsafeL2.L1Origin.Number, "no L1 origin change before time matches")
 			l2BlockCount++
-			if l2BlockCount == 12 {
+			if l2BlockCount == 23 {
 				require.Equal(t, 1, fallbackClient.GetCurrentIndex(), "fallback client should switch url to second url")
 				errRpc2 := miner.RPCClient().CallContext(t.Ctx(), nil, "admin_startHTTP", "127.0.0.1", 8545, "*", "eth,net,web3,debug,admin,txpool", "*")
 				require.NoError(t, errRpc2)
 			}
-			if l2BlockCount == 20 {
+			if l2BlockCount == 34 {
 				require.Equal(t, 0, fallbackClient.GetCurrentIndex(), "fallback client should recover url to first url")
 			}
-			time.Sleep(1 * time.Second)
+			time.Sleep(500 * time.Millisecond)
 		}
 	}
 }

--- a/op-e2e/actions/l1_miner.go
+++ b/op-e2e/actions/l1_miner.go
@@ -39,6 +39,13 @@ func NewL1Miner(t Testing, log log.Logger, genesis *core.Genesis) *L1Miner {
 	}
 }
 
+func NewL1MinerWithPort(t Testing, log log.Logger, genesis *core.Genesis, port int) *L1Miner {
+	rep := NewL1ReplicaWithPort(t, log, genesis, port)
+	return &L1Miner{
+		L1Replica: *rep,
+	}
+}
+
 // ActL1StartBlock returns an action to build a new L1 block on top of the head block,
 // with timeDelta added to the head block time.
 func (s *L1Miner) ActL1StartBlock(timeDelta uint64) Action {

--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -25,7 +25,7 @@ var (
 	/* Required Flags */
 	L1NodeAddr = cli.StringFlag{
 		Name:   "l1",
-		Usage:  "Address of L1 User JSON-RPC endpoint to use (eth namespace required)",
+		Usage:  "Address of L1 User JSON-RPC endpoint to use (eth namespace required). Multiple alternative addresses are supported, separated by commas, and the first address is used by default",
 		Value:  "http://127.0.0.1:8545",
 		EnvVar: prefixEnvVar("L1_ETH_RPC"),
 	}

--- a/op-node/metrics/metrics.go
+++ b/op-node/metrics/metrics.go
@@ -76,6 +76,7 @@ type Metricer interface {
 	RecordIPUnban()
 	RecordDial(allow bool)
 	RecordAccept(allow bool)
+	RecordL1UrlSwitchEvent()
 }
 
 // Metrics tracks all the metrics for the op-node.
@@ -99,6 +100,7 @@ type Metrics struct {
 	DerivationErrors *EventMetrics
 	SequencingErrors *EventMetrics
 	PublishingErrors *EventMetrics
+	L1UrlSwitchEvent *EventMetrics
 
 	P2PReqDurationSeconds *prometheus.HistogramVec
 	P2PReqTotal           *prometheus.CounterVec
@@ -236,6 +238,7 @@ func NewMetrics(procName string) *Metrics {
 		DerivationErrors: NewEventMetrics(factory, ns, "derivation_errors", "derivation errors"),
 		SequencingErrors: NewEventMetrics(factory, ns, "sequencing_errors", "sequencing errors"),
 		PublishingErrors: NewEventMetrics(factory, ns, "publishing_errors", "p2p publishing errors"),
+		L1UrlSwitchEvent: NewEventMetrics(factory, ns, "l1_url_switch_event", "L1 URL switch events"),
 
 		SequencerInconsistentL1Origin: NewEventMetrics(factory, ns, "sequencer_inconsistent_l1_origin", "events when the sequencer selects an inconsistent L1 origin"),
 		SequencerResets:               NewEventMetrics(factory, ns, "sequencer_resets", "sequencer resets"),
@@ -725,6 +728,10 @@ func (m *Metrics) RecordAccept(allow bool) {
 	}
 }
 
+func (m *Metrics) RecordL1UrlSwitchEvent() {
+	m.L1UrlSwitchEvent.RecordEvent()
+}
+
 type noopMetricer struct{}
 
 var NoopMetrics Metricer = new(noopMetricer)
@@ -844,4 +851,7 @@ func (n *noopMetricer) RecordDial(allow bool) {
 }
 
 func (n *noopMetricer) RecordAccept(allow bool) {
+}
+
+func (n *noopMetricer) RecordL1UrlSwitchEvent() {
 }

--- a/op-node/metrics/metrics.go
+++ b/op-node/metrics/metrics.go
@@ -238,7 +238,7 @@ func NewMetrics(procName string) *Metrics {
 		DerivationErrors: NewEventMetrics(factory, ns, "derivation_errors", "derivation errors"),
 		SequencingErrors: NewEventMetrics(factory, ns, "sequencing_errors", "sequencing errors"),
 		PublishingErrors: NewEventMetrics(factory, ns, "publishing_errors", "p2p publishing errors"),
-		L1UrlSwitchEvent: NewEventMetrics(factory, ns, "l1_url_switch_event", "L1 URL switch events"),
+		L1UrlSwitchEvent: NewEventMetrics(factory, ns, "l1_url_switch", "L1 URL switch events"),
 
 		SequencerInconsistentL1Origin: NewEventMetrics(factory, ns, "sequencer_inconsistent_l1_origin", "events when the sequencer selects an inconsistent L1 origin"),
 		SequencerResets:               NewEventMetrics(factory, ns, "sequencer_resets", "sequencer resets"),

--- a/op-node/node/client.go
+++ b/op-node/node/client.go
@@ -186,7 +186,7 @@ func (cfg *L1EndpointConfig) Setup(ctx context.Context, log log.Logger, rollupCf
 		return nil, nil, fmt.Errorf("failed to dial L1 address (%s): %w", L1NodeAddrUse, err)
 	}
 	if isMultiUrl {
-		l1Node = sources.NewFallbackClient(l1Node, urlList, log, func(url string) (client.RPC, error) {
+		l1Node = sources.NewFallbackClient(ctx, l1Node, urlList, log, rollupCfg.L1ChainID, rollupCfg.Genesis.L1, func(url string) (client.RPC, error) {
 			return client.NewRPC(ctx, log, url, opts...)
 		})
 	}

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -138,6 +138,12 @@ func (n *OpNode) initL1(ctx context.Context, cfg *Config) error {
 		}
 		return eth.WatchHeadChanges(n.resourcesCtx, n.l1Source, n.OnNewL1Head)
 	})
+
+	if fallbackClient, ok := l1Node.(*sources.FallbackClient); ok {
+		fallbackClient.RegisterSubscribeFunc(func() (event.Subscription, error) {
+			return eth.WatchHeadChanges(n.resourcesCtx, fallbackClient, n.OnNewL1Head)
+		}, &n.l1HeadsSub)
+	}
 	go func() {
 		err, ok := <-n.l1HeadsSub.Err()
 		if !ok {

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -143,6 +143,7 @@ func (n *OpNode) initL1(ctx context.Context, cfg *Config) error {
 		fallbackClient.RegisterSubscribeFunc(func() (event.Subscription, error) {
 			return eth.WatchHeadChanges(n.resourcesCtx, n.l1Source, n.OnNewL1Head)
 		}, &n.l1HeadsSub)
+		fallbackClient.RegisterMetrics(n.metrics)
 	}
 	go func() {
 		err, ok := <-n.l1HeadsSub.Err()

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -141,7 +141,7 @@ func (n *OpNode) initL1(ctx context.Context, cfg *Config) error {
 
 	if fallbackClient, ok := l1Node.(*sources.FallbackClient); ok {
 		fallbackClient.RegisterSubscribeFunc(func() (event.Subscription, error) {
-			return eth.WatchHeadChanges(n.resourcesCtx, fallbackClient, n.OnNewL1Head)
+			return eth.WatchHeadChanges(n.resourcesCtx, n.l1Source, n.OnNewL1Head)
 		}, &n.l1HeadsSub)
 	}
 	go func() {

--- a/op-node/sources/fallback_client.go
+++ b/op-node/sources/fallback_client.go
@@ -1,0 +1,129 @@
+package sources
+
+import (
+	"context"
+	"github.com/ethereum-optimism/optimism/op-node/client"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type FallbackClient struct {
+	firstRpc          client.RPC
+	urlList           []string
+	rpcInitFunc       func(url string) (client.RPC, error)
+	lastMinuteFail    atomic.Int64
+	currentRpc        client.RPC
+	currentIndex      int
+	mx                sync.Mutex
+	log               log.Logger
+	isInFallbackState bool
+}
+
+func NewFallbackClient(rpc client.RPC, urlList []string, log log.Logger, rpcInitFunc func(url string) (client.RPC, error)) client.RPC {
+	fallbackClient := &FallbackClient{firstRpc: rpc, urlList: urlList, log: log, rpcInitFunc: rpcInitFunc, currentRpc: rpc, currentIndex: 0}
+	go func() {
+		ticker := time.NewTicker(1 * time.Minute)
+		for {
+			select {
+			case <-ticker.C:
+				fallbackClient.lastMinuteFail.Store(0)
+			}
+		}
+	}()
+	return fallbackClient
+}
+
+func (l *FallbackClient) Close() {
+	l.currentRpc.Close()
+	if l.currentRpc != l.firstRpc {
+		l.firstRpc.Close()
+	}
+}
+
+func (l *FallbackClient) CallContext(ctx context.Context, result any, method string, args ...any) error {
+	err := l.currentRpc.CallContext(ctx, result, method, args)
+	if err != nil {
+		l.handleErr(err)
+	}
+	return err
+}
+
+func (l *FallbackClient) handleErr(err error) {
+	if err == rpc.ErrNoResult {
+		return
+	}
+	errCount := l.lastMinuteFail.Add(1)
+	if errCount > 10 {
+		l.switchCurrentRpc()
+	}
+}
+
+func (l *FallbackClient) BatchCallContext(ctx context.Context, b []rpc.BatchElem) error {
+	err := l.currentRpc.BatchCallContext(ctx, b)
+	if err != nil {
+		l.handleErr(err)
+	}
+	return err
+}
+
+func (l *FallbackClient) EthSubscribe(ctx context.Context, channel any, args ...any) (ethereum.Subscription, error) {
+	subscribe, err := l.currentRpc.EthSubscribe(ctx, channel, args)
+	if err != nil {
+		l.handleErr(err)
+	}
+	return subscribe, err
+}
+
+func (l *FallbackClient) switchCurrentRpc() {
+	l.mx.Lock()
+	defer l.mx.Unlock()
+	l.currentIndex++
+	if l.currentIndex >= len(l.urlList) {
+		log.Error("fallback client has tried all urls")
+		return
+	}
+	url := l.urlList[l.currentIndex]
+	newRpc, err := l.rpcInitFunc(url)
+	if err != nil {
+		log.Error("fallback client switch current RPC fail", "url", url, "err", err)
+		return
+	}
+	if l.currentRpc != l.firstRpc {
+		l.currentRpc.Close()
+	}
+	l.lastMinuteFail.Store(0)
+	l.currentRpc = newRpc
+	if !l.isInFallbackState {
+		l.isInFallbackState = true
+		l.recoverIfFirstRpcHealth()
+	}
+}
+
+func (l *FallbackClient) recoverIfFirstRpcHealth() {
+	go func() {
+		for {
+			var id hexutil.Big
+			err := l.firstRpc.CallContext(context.Background(), &id, "eth_chainId")
+			if err != nil {
+				time.Sleep(5 * time.Second)
+				continue
+			}
+			break
+		}
+		l.mx.Lock()
+		defer l.mx.Unlock()
+		if !l.isInFallbackState {
+			return
+		}
+		l.currentRpc.Close()
+		l.lastMinuteFail.Store(0)
+		l.currentRpc = l.firstRpc
+		l.currentIndex = 0
+		l.isInFallbackState = false
+	}()
+}

--- a/op-node/sources/fallback_client.go
+++ b/op-node/sources/fallback_client.go
@@ -35,6 +35,7 @@ func NewFallbackClient(rpc client.RPC, urlList []string, log log.Logger, rpcInit
 		for {
 			select {
 			case <-ticker.C:
+				log.Debug("FallbackClient clear lastMinuteFail 0")
 				fallbackClient.lastMinuteFail.Store(0)
 			}
 		}
@@ -107,8 +108,8 @@ func (l *FallbackClient) switchCurrentRpc() {
 	if l.currentRpc != l.firstRpc {
 		l.currentRpc.Close()
 	}
-	l.lastMinuteFail.Store(0)
 	l.currentRpc = newRpc
+	l.lastMinuteFail.Store(0)
 	if l.subscribeFunc != nil {
 		l.reSubscribeNewRpc(url)
 	}
@@ -151,8 +152,8 @@ func (l *FallbackClient) recoverIfFirstRpcHealth() {
 			return
 		}
 		l.currentRpc.Close()
-		l.lastMinuteFail.Store(0)
 		l.currentRpc = l.firstRpc
+		l.lastMinuteFail.Store(0)
 		l.currentIndex = 0
 		l.isInFallbackState = false
 		if l.subscribeFunc != nil {

--- a/op-node/sources/fallback_client.go
+++ b/op-node/sources/fallback_client.go
@@ -82,6 +82,9 @@ func (l *FallbackClient) EthSubscribe(ctx context.Context, channel any, args ...
 func (l *FallbackClient) switchCurrentRpc() {
 	l.mx.Lock()
 	defer l.mx.Unlock()
+	if l.lastMinuteFail.Load() <= 10 {
+		return
+	}
 	l.currentIndex++
 	if l.currentIndex >= len(l.urlList) {
 		log.Error("fallback client has tried all urls")

--- a/op-node/sources/fallback_client.go
+++ b/op-node/sources/fallback_client.go
@@ -40,7 +40,7 @@ type FallbackClient struct {
 	metrics           metrics.Metricer
 }
 
-const threshold int64 = 10
+const threshold int64 = 20
 
 // NewFallbackClient returns a new FallbackClient. l1ChainId and l1Block are used to check
 // whether the newly switched rpc is legal.

--- a/op-node/sources/fallback_client.go
+++ b/op-node/sources/fallback_client.go
@@ -105,10 +105,11 @@ func (l *FallbackClient) switchCurrentRpc() {
 		log.Error("fallback client switch current RPC fail", "url", url, "err", err)
 		return
 	}
-	if l.currentRpc != l.firstRpc {
-		l.currentRpc.Close()
-	}
+	lastRpc := l.currentRpc
 	l.currentRpc = newRpc
+	if lastRpc != l.firstRpc {
+		lastRpc.Close()
+	}
 	l.lastMinuteFail.Store(0)
 	if l.subscribeFunc != nil {
 		l.reSubscribeNewRpc(url)
@@ -151,8 +152,9 @@ func (l *FallbackClient) recoverIfFirstRpcHealth() {
 		if !l.isInFallbackState {
 			return
 		}
-		l.currentRpc.Close()
+		lastRpc := l.currentRpc
 		l.currentRpc = l.firstRpc
+		lastRpc.Close()
 		l.lastMinuteFail.Store(0)
 		l.currentIndex = 0
 		l.isInFallbackState = false

--- a/op-node/sources/fallback_client.go
+++ b/op-node/sources/fallback_client.go
@@ -54,6 +54,7 @@ func NewFallbackClient(ctx context.Context, rpc client.RPC, urlList []string, lo
 		currentIndex: 0,
 		l1ChainId:    l1ChainId,
 		l1Block:      l1Block,
+		isClose:      make(chan struct{}),
 	}
 	fallbackClient.currentRpc.Store(&rpc)
 	go func() {

--- a/op-node/sources/fallback_client.go
+++ b/op-node/sources/fallback_client.go
@@ -66,7 +66,7 @@ func NewFallbackClient(ctx context.Context, rpc client.RPC, urlList []string, lo
 			case <-fallbackClient.isClose:
 				return
 			default:
-				if fallbackClient.lastMinuteFail.Load() > threshold {
+				if fallbackClient.lastMinuteFail.Load() >= threshold {
 					fallbackClient.switchCurrentRpc()
 				}
 			}

--- a/op-node/sources/fallback_client.go
+++ b/op-node/sources/fallback_client.go
@@ -199,7 +199,7 @@ func (l *FallbackClient) recoverIfFirstRpcHealth() {
 			err := l.firstRpc.CallContext(l.ctx, &id, "eth_chainId")
 			if err != nil {
 				count = 0
-				time.Sleep(5 * time.Second)
+				time.Sleep(3 * time.Second)
 				continue
 			}
 			count++
@@ -271,4 +271,8 @@ func (l *FallbackClient) l1BlockRefByNumber(ctx context.Context, number uint64, 
 
 func (l *FallbackClient) RegisterMetrics(metrics metrics.Metricer) {
 	l.metrics = metrics
+}
+
+func (l *FallbackClient) GetCurrentIndex() int {
+	return l.currentIndex
 }

--- a/op-proposer/flags/flags.go
+++ b/op-proposer/flags/flags.go
@@ -20,7 +20,7 @@ var (
 	// Required Flags
 	L1EthRpcFlag = cli.StringFlag{
 		Name:   "l1-eth-rpc",
-		Usage:  "HTTP provider URL for L1",
+		Usage:  "HTTP provider URL for L1. Multiple alternative addresses are supported, separated by commas, and the first address is used by default",
 		EnvVar: opservice.PrefixEnvVar(EnvVarPrefix, "L1_ETH_RPC"),
 	}
 	RollupRpcFlag = cli.StringFlag{

--- a/op-proposer/metrics/metrics.go
+++ b/op-proposer/metrics/metrics.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"context"
+
 	"github.com/ethereum/go-ethereum"
 
 	"github.com/ethereum-optimism/optimism/op-node/eth"

--- a/op-proposer/metrics/metrics.go
+++ b/op-proposer/metrics/metrics.go
@@ -2,11 +2,11 @@ package metrics
 
 import (
 	"context"
+	"github.com/ethereum/go-ethereum"
 
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -80,7 +80,7 @@ func (m *Metrics) Serve(ctx context.Context, host string, port int) error {
 }
 
 func (m *Metrics) StartBalanceMetrics(ctx context.Context,
-	l log.Logger, client *ethclient.Client, account common.Address) {
+	l log.Logger, client ethereum.ChainStateReader, account common.Address) {
 	opmetrics.LaunchBalanceMetrics(ctx, l, m.registry, m.ns, client, account)
 }
 

--- a/op-proposer/metrics/noop.go
+++ b/op-proposer/metrics/noop.go
@@ -17,3 +17,6 @@ func (*noopMetrics) RecordInfo(version string) {}
 func (*noopMetrics) RecordUp()                 {}
 
 func (*noopMetrics) RecordL2BlocksProposed(l2ref eth.L2BlockRef) {}
+
+func (m *noopMetrics) RecordL1UrlSwitchEvt(url string) {
+}

--- a/op-proposer/proposer/config.go
+++ b/op-proposer/proposer/config.go
@@ -1,10 +1,10 @@
 package proposer
 
 import (
+	"github.com/ethereum-optimism/optimism/op-service/client"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/urfave/cli"
 
 	"github.com/ethereum-optimism/optimism/op-node/sources"
@@ -24,7 +24,7 @@ type Config struct {
 	PollInterval       time.Duration
 	NetworkTimeout     time.Duration
 	TxManager          txmgr.TxManager
-	L1Client           *ethclient.Client
+	L1Client           client.EthClient
 	RollupClient       *sources.RollupClient
 	AllowNonFinalized  bool
 }

--- a/op-proposer/proposer/config.go
+++ b/op-proposer/proposer/config.go
@@ -1,8 +1,9 @@
 package proposer
 
 import (
-	"github.com/ethereum-optimism/optimism/op-service/client"
 	"time"
+
+	"github.com/ethereum-optimism/optimism/op-service/client"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/urfave/cli"

--- a/op-proposer/proposer/l2_output_submitter.go
+++ b/op-proposer/proposer/l2_output_submitter.go
@@ -158,7 +158,7 @@ func NewL2OutputSubmitterConfigFromCLIConfig(cfg CLIConfig, l log.Logger, m metr
 
 	// Connect to L1 and L2 providers. Perform these last since they are the most expensive.
 	ctx := context.Background()
-	l1Client, err := opclient.DialEthClientWithTimeout(ctx, cfg.L1EthRpc, opclient.DefaultDialTimeout)
+	l1Client, err := opclient.DialEthClientWithTimeoutAndFallback(ctx, cfg.L1EthRpc, opclient.DefaultDialTimeout, l)
 	if err != nil {
 		return nil, err
 	}

--- a/op-proposer/proposer/l2_output_submitter.go
+++ b/op-proposer/proposer/l2_output_submitter.go
@@ -158,7 +158,7 @@ func NewL2OutputSubmitterConfigFromCLIConfig(cfg CLIConfig, l log.Logger, m metr
 
 	// Connect to L1 and L2 providers. Perform these last since they are the most expensive.
 	ctx := context.Background()
-	l1Client, err := opclient.DialEthClientWithTimeoutAndFallback(ctx, cfg.L1EthRpc, opclient.DefaultDialTimeout, l, 3)
+	l1Client, err := opclient.DialEthClientWithTimeoutAndFallback(ctx, cfg.L1EthRpc, opclient.DefaultDialTimeout, l, 3, m)
 	if err != nil {
 		return nil, err
 	}

--- a/op-proposer/proposer/l2_output_submitter.go
+++ b/op-proposer/proposer/l2_output_submitter.go
@@ -158,7 +158,7 @@ func NewL2OutputSubmitterConfigFromCLIConfig(cfg CLIConfig, l log.Logger, m metr
 
 	// Connect to L1 and L2 providers. Perform these last since they are the most expensive.
 	ctx := context.Background()
-	l1Client, err := opclient.DialEthClientWithTimeoutAndFallback(ctx, cfg.L1EthRpc, opclient.DefaultDialTimeout, l)
+	l1Client, err := opclient.DialEthClientWithTimeoutAndFallback(ctx, cfg.L1EthRpc, opclient.DefaultDialTimeout, l, 3)
 	if err != nil {
 		return nil, err
 	}

--- a/op-proposer/proposer/l2_output_submitter.go
+++ b/op-proposer/proposer/l2_output_submitter.go
@@ -158,7 +158,7 @@ func NewL2OutputSubmitterConfigFromCLIConfig(cfg CLIConfig, l log.Logger, m metr
 
 	// Connect to L1 and L2 providers. Perform these last since they are the most expensive.
 	ctx := context.Background()
-	l1Client, err := opclient.DialEthClientWithTimeoutAndFallback(ctx, cfg.L1EthRpc, opclient.DefaultDialTimeout, l, 3, m)
+	l1Client, err := opclient.DialEthClientWithTimeoutAndFallback(ctx, cfg.L1EthRpc, opclient.DefaultDialTimeout, l, opclient.ProposerFallbackThreshold, m)
 	if err != nil {
 		return nil, err
 	}

--- a/op-service/client/ethclient.go
+++ b/op-service/client/ethclient.go
@@ -22,6 +22,10 @@ func DialEthClientWithTimeout(ctx context.Context, url string, timeout time.Dura
 	return ethclient.DialContext(ctxt, url)
 }
 
+const BatcherFallbackThreshold int64 = 10
+const ProposerFallbackThreshold int64 = 3
+const TxmgrFallbackThreshold int64 = 3
+
 // DialEthClientWithTimeoutAndFallback will try to dial within the timeout period and create an EthClient.
 // If the URL is a multi URL, then a fallbackClient will be created to add the fallback capability to the client
 func DialEthClientWithTimeoutAndFallback(ctx context.Context, url string, timeout time.Duration, l log.Logger, fallbackThreshold int64, m FallbackClientMetricer) (EthClient, error) {

--- a/op-service/client/ethclient.go
+++ b/op-service/client/ethclient.go
@@ -22,7 +22,8 @@ func DialEthClientWithTimeout(ctx context.Context, url string, timeout time.Dura
 	return ethclient.DialContext(ctxt, url)
 }
 
-// DialEthClientWithTimeoutAndFallback s
+// DialEthClientWithTimeoutAndFallback will try to dial within the timeout period and create an EthClient.
+// If the URL is a multi URL, then a fallbackClient will be created to add the fallback capability to the client
 func DialEthClientWithTimeoutAndFallback(ctx context.Context, url string, timeout time.Duration, l log.Logger, fallbackThreshold int64) (EthClient, error) {
 	ctxt, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()

--- a/op-service/client/ethclient.go
+++ b/op-service/client/ethclient.go
@@ -24,7 +24,7 @@ func DialEthClientWithTimeout(ctx context.Context, url string, timeout time.Dura
 
 // DialEthClientWithTimeoutAndFallback will try to dial within the timeout period and create an EthClient.
 // If the URL is a multi URL, then a fallbackClient will be created to add the fallback capability to the client
-func DialEthClientWithTimeoutAndFallback(ctx context.Context, url string, timeout time.Duration, l log.Logger, fallbackThreshold int64) (EthClient, error) {
+func DialEthClientWithTimeoutAndFallback(ctx context.Context, url string, timeout time.Duration, l log.Logger, fallbackThreshold int64, m FallbackClientMetricer) (EthClient, error) {
 	ctxt, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	isMultiUrl, urlList := MultiUrlParse(url)
@@ -33,7 +33,7 @@ func DialEthClientWithTimeoutAndFallback(ctx context.Context, url string, timeou
 		if err != nil {
 			return nil, err
 		}
-		fallbackClient := NewFallbackClient(firstEthClient, urlList, l, fallbackThreshold, func(url string) (EthClient, error) {
+		fallbackClient := NewFallbackClient(firstEthClient, urlList, l, fallbackThreshold, m, func(url string) (EthClient, error) {
 			ctxtIn, cancelIn := context.WithTimeout(ctx, timeout)
 			defer cancelIn()
 			ethClientNew, err := ethclient.DialContext(ctxtIn, url)

--- a/op-service/client/ethclient.go
+++ b/op-service/client/ethclient.go
@@ -23,7 +23,7 @@ func DialEthClientWithTimeout(ctx context.Context, url string, timeout time.Dura
 }
 
 // DialEthClientWithTimeoutAndFallback s
-func DialEthClientWithTimeoutAndFallback(ctx context.Context, url string, timeout time.Duration, l log.Logger) (EthClient, error) {
+func DialEthClientWithTimeoutAndFallback(ctx context.Context, url string, timeout time.Duration, l log.Logger, fallbackThreshold int64) (EthClient, error) {
 	ctxt, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	isMultiUrl, urlList := MultiUrlParse(url)
@@ -32,7 +32,7 @@ func DialEthClientWithTimeoutAndFallback(ctx context.Context, url string, timeou
 		if err != nil {
 			return nil, err
 		}
-		fallbackClient := NewFallbackClient(firstEthClient, urlList, l, func(url string) (EthClient, error) {
+		fallbackClient := NewFallbackClient(firstEthClient, urlList, l, fallbackThreshold, func(url string) (EthClient, error) {
 			ctxtIn, cancelIn := context.WithTimeout(ctx, timeout)
 			defer cancelIn()
 			ethClientNew, err := ethclient.DialContext(ctxtIn, url)

--- a/op-service/client/fallback_client.go
+++ b/op-service/client/fallback_client.go
@@ -64,7 +64,7 @@ func (l *FallbackClient) TransactionReceipt(ctx context.Context, txHash common.H
 }
 
 func (l *FallbackClient) SendTransaction(ctx context.Context, tx *types.Transaction) error {
-	err := l.SendTransaction(ctx, tx)
+	err := l.currentClient.SendTransaction(ctx, tx)
 	if err != nil {
 		l.handleErr(err)
 	}
@@ -72,7 +72,7 @@ func (l *FallbackClient) SendTransaction(ctx context.Context, tx *types.Transact
 }
 
 func (l *FallbackClient) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
-	tipCap, err := l.SuggestGasTipCap(ctx)
+	tipCap, err := l.currentClient.SuggestGasTipCap(ctx)
 	if err != nil {
 		l.handleErr(err)
 	}
@@ -80,7 +80,7 @@ func (l *FallbackClient) SuggestGasTipCap(ctx context.Context) (*big.Int, error)
 }
 
 func (l *FallbackClient) PendingNonceAt(ctx context.Context, account common.Address) (uint64, error) {
-	at, err := l.PendingNonceAt(ctx, account)
+	at, err := l.currentClient.PendingNonceAt(ctx, account)
 	if err != nil {
 		l.handleErr(err)
 	}
@@ -88,7 +88,7 @@ func (l *FallbackClient) PendingNonceAt(ctx context.Context, account common.Addr
 }
 
 func (l *FallbackClient) EstimateGas(ctx context.Context, msg ethereum.CallMsg) (uint64, error) {
-	estimateGas, err := l.EstimateGas(ctx, msg)
+	estimateGas, err := l.currentClient.EstimateGas(ctx, msg)
 	if err != nil {
 		l.handleErr(err)
 	}
@@ -119,23 +119,43 @@ func (l *FallbackClient) ChainID(ctx context.Context) (*big.Int, error) {
 }
 
 func (l *FallbackClient) BalanceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (*big.Int, error) {
-	return l.currentClient.BalanceAt(ctx, account, blockNumber)
+	balanceAt, err := l.currentClient.BalanceAt(ctx, account, blockNumber)
+	if err != nil {
+		l.handleErr(err)
+	}
+	return balanceAt, err
 }
 
 func (l *FallbackClient) HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error) {
-	return l.HeaderByNumber(ctx, number)
+	headerByNumber, err := l.currentClient.HeaderByNumber(ctx, number)
+	if err != nil {
+		l.handleErr(err)
+	}
+	return headerByNumber, err
 }
 
 func (l *FallbackClient) StorageAt(ctx context.Context, account common.Address, key common.Hash, blockNumber *big.Int) ([]byte, error) {
-	return l.StorageAt(ctx, account, key, blockNumber)
+	storageAt, err := l.currentClient.StorageAt(ctx, account, key, blockNumber)
+	if err != nil {
+		l.handleErr(err)
+	}
+	return storageAt, err
 }
 
 func (l *FallbackClient) CodeAt(ctx context.Context, account common.Address, blockNumber *big.Int) ([]byte, error) {
-	return l.CodeAt(ctx, account, blockNumber)
+	codeAt, err := l.currentClient.CodeAt(ctx, account, blockNumber)
+	if err != nil {
+		l.handleErr(err)
+	}
+	return codeAt, err
 }
 
 func (l *FallbackClient) NonceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (uint64, error) {
-	return l.NonceAt(ctx, account, blockNumber)
+	nonceAt, err := l.currentClient.NonceAt(ctx, account, blockNumber)
+	if err != nil {
+		l.handleErr(err)
+	}
+	return nonceAt, err
 }
 
 func (l *FallbackClient) handleErr(err error) {

--- a/op-service/client/fallback_client.go
+++ b/op-service/client/fallback_client.go
@@ -1,0 +1,12 @@
+package client
+
+import (
+	"strings"
+)
+
+func MultiUrlParse(url string) (isMultiUrl bool, urlList []string) {
+	if strings.Contains(url, ",") {
+		return true, strings.Split(url, ",")
+	}
+	return false, []string{}
+}

--- a/op-service/client/fallback_client.go
+++ b/op-service/client/fallback_client.go
@@ -40,6 +40,7 @@ func NewFallbackClient(rpc EthClient, urlList []string, log log.Logger, clientIn
 		for {
 			select {
 			case <-ticker.C:
+				log.Debug("FallbackClient clear lastMinuteFail 0")
 				fallbackClient.lastMinuteFail.Store(0)
 			}
 		}
@@ -188,8 +189,8 @@ func (l *FallbackClient) switchCurrentClient() {
 	if l.currentClient != l.firstClient {
 		l.currentClient.Close()
 	}
-	l.lastMinuteFail.Store(0)
 	l.currentClient = newClient
+	l.lastMinuteFail.Store(0)
 	log.Info("switch current client new url", "url", url)
 	if !l.isInFallbackState {
 		l.isInFallbackState = true
@@ -218,8 +219,8 @@ func (l *FallbackClient) recoverIfFirstRpcHealth() {
 			return
 		}
 		l.currentClient.Close()
-		l.lastMinuteFail.Store(0)
 		l.currentClient = l.firstClient
+		l.lastMinuteFail.Store(0)
 		l.currentIndex = 0
 		l.isInFallbackState = false
 		log.Info("recover current client to first client", "url", l.urlList[0])

--- a/op-service/client/fallback_client.go
+++ b/op-service/client/fallback_client.go
@@ -1,7 +1,17 @@
 package client
 
 import (
+	"context"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
+	"math/big"
 	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
 )
 
 func MultiUrlParse(url string) (isMultiUrl bool, urlList []string) {
@@ -9,4 +19,189 @@ func MultiUrlParse(url string) (isMultiUrl bool, urlList []string) {
 		return true, strings.Split(url, ",")
 	}
 	return false, []string{}
+}
+
+type FallbackClient struct {
+	firstClient       EthClient
+	urlList           []string
+	clientInitFunc    func(url string) (EthClient, error)
+	lastMinuteFail    atomic.Int64
+	currentClient     EthClient
+	currentIndex      int
+	mx                sync.Mutex
+	log               log.Logger
+	isInFallbackState bool
+}
+
+func NewFallbackClient(rpc EthClient, urlList []string, log log.Logger, clientInitFunc func(url string) (EthClient, error)) EthClient {
+	fallbackClient := &FallbackClient{firstClient: rpc, urlList: urlList, log: log, clientInitFunc: clientInitFunc, currentClient: rpc, currentIndex: 0}
+	go func() {
+		ticker := time.NewTicker(1 * time.Minute)
+		for {
+			select {
+			case <-ticker.C:
+				fallbackClient.lastMinuteFail.Store(0)
+			}
+		}
+	}()
+	return fallbackClient
+}
+
+func (l *FallbackClient) BlockNumber(ctx context.Context) (uint64, error) {
+	number, err := l.currentClient.BlockNumber(ctx)
+	if err != nil {
+		l.handleErr(err)
+	}
+	return number, err
+}
+
+func (l *FallbackClient) TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
+	receipt, err := l.currentClient.TransactionReceipt(ctx, txHash)
+	if err != nil {
+		l.handleErr(err)
+	}
+	return receipt, err
+}
+
+func (l *FallbackClient) SendTransaction(ctx context.Context, tx *types.Transaction) error {
+	err := l.SendTransaction(ctx, tx)
+	if err != nil {
+		l.handleErr(err)
+	}
+	return err
+}
+
+func (l *FallbackClient) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
+	tipCap, err := l.SuggestGasTipCap(ctx)
+	if err != nil {
+		l.handleErr(err)
+	}
+	return tipCap, err
+}
+
+func (l *FallbackClient) PendingNonceAt(ctx context.Context, account common.Address) (uint64, error) {
+	at, err := l.PendingNonceAt(ctx, account)
+	if err != nil {
+		l.handleErr(err)
+	}
+	return at, err
+}
+
+func (l *FallbackClient) EstimateGas(ctx context.Context, msg ethereum.CallMsg) (uint64, error) {
+	estimateGas, err := l.EstimateGas(ctx, msg)
+	if err != nil {
+		l.handleErr(err)
+	}
+	return estimateGas, err
+}
+
+func (l *FallbackClient) CallContract(ctx context.Context, call ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+	contract, err := l.currentClient.CallContract(ctx, call, blockNumber)
+	if err != nil {
+		l.handleErr(err)
+	}
+	return contract, err
+}
+
+func (l *FallbackClient) Close() {
+	l.currentClient.Close()
+	if l.currentClient != l.firstClient {
+		l.firstClient.Close()
+	}
+}
+
+func (l *FallbackClient) ChainID(ctx context.Context) (*big.Int, error) {
+	id, err := l.currentClient.ChainID(ctx)
+	if err != nil {
+		l.handleErr(err)
+	}
+	return id, err
+}
+
+func (l *FallbackClient) BalanceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (*big.Int, error) {
+	return l.currentClient.BalanceAt(ctx, account, blockNumber)
+}
+
+func (l *FallbackClient) HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error) {
+	return l.HeaderByNumber(ctx, number)
+}
+
+func (l *FallbackClient) StorageAt(ctx context.Context, account common.Address, key common.Hash, blockNumber *big.Int) ([]byte, error) {
+	return l.StorageAt(ctx, account, key, blockNumber)
+}
+
+func (l *FallbackClient) CodeAt(ctx context.Context, account common.Address, blockNumber *big.Int) ([]byte, error) {
+	return l.CodeAt(ctx, account, blockNumber)
+}
+
+func (l *FallbackClient) NonceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (uint64, error) {
+	return l.NonceAt(ctx, account, blockNumber)
+}
+
+func (l *FallbackClient) handleErr(err error) {
+	if err == rpc.ErrNoResult {
+		return
+	}
+	errCount := l.lastMinuteFail.Add(1)
+	if errCount > 10 {
+		l.switchCurrentClient()
+	}
+}
+
+func (l *FallbackClient) switchCurrentClient() {
+	l.mx.Lock()
+	defer l.mx.Unlock()
+	if l.lastMinuteFail.Load() <= 10 {
+		return
+	}
+	l.currentIndex++
+	if l.currentIndex >= len(l.urlList) {
+		log.Error("fallback client has tried all urls")
+		return
+	}
+	url := l.urlList[l.currentIndex]
+	newClient, err := l.clientInitFunc(url)
+	if err != nil {
+		log.Error("fallback client switch current client fail", "url", url, "err", err)
+		return
+	}
+	if l.currentClient != l.firstClient {
+		l.currentClient.Close()
+	}
+	l.lastMinuteFail.Store(0)
+	l.currentClient = newClient
+	log.Info("switch current client new url", "url", url)
+	if !l.isInFallbackState {
+		l.isInFallbackState = true
+		l.recoverIfFirstRpcHealth()
+	}
+}
+
+func (l *FallbackClient) recoverIfFirstRpcHealth() {
+	go func() {
+		count := 0
+		for {
+			_, err := l.firstClient.ChainID(context.Background())
+			if err != nil {
+				count = 0
+				time.Sleep(5 * time.Second)
+				continue
+			}
+			count++
+			if count >= 3 {
+				break
+			}
+		}
+		l.mx.Lock()
+		defer l.mx.Unlock()
+		if !l.isInFallbackState {
+			return
+		}
+		l.currentClient.Close()
+		l.lastMinuteFail.Store(0)
+		l.currentClient = l.firstClient
+		l.currentIndex = 0
+		l.isInFallbackState = false
+		log.Info("recover current client to first client", "url", l.urlList[0])
+	}()
 }

--- a/op-service/client/fallback_client.go
+++ b/op-service/client/fallback_client.go
@@ -256,7 +256,7 @@ func (l *FallbackClient) recoverIfFirstRpcHealth() {
 			_, err := l.firstClient.ChainID(context.Background())
 			if err != nil {
 				count = 0
-				time.Sleep(5 * time.Second)
+				time.Sleep(3 * time.Second)
 				continue
 			}
 			count++

--- a/op-service/client/fallback_client.go
+++ b/op-service/client/fallback_client.go
@@ -186,13 +186,13 @@ func (l *FallbackClient) switchCurrentClient() {
 	}
 	l.currentIndex++
 	if l.currentIndex >= len(l.urlList) {
-		log.Error("fallback client has tried all urls")
+		l.log.Error("fallback client has tried all urls")
 		return
 	}
 	url := l.urlList[l.currentIndex]
 	newClient, err := l.clientInitFunc(url)
 	if err != nil {
-		log.Error("fallback client switch current client fail", "url", url, "err", err)
+		l.log.Error("fallback client switch current client fail", "url", url, "err", err)
 		return
 	}
 	lastClient := l.currentClient
@@ -201,7 +201,7 @@ func (l *FallbackClient) switchCurrentClient() {
 		lastClient.Close()
 	}
 	l.lastMinuteFail.Store(0)
-	log.Info("switch current client new url", "url", url)
+	l.log.Info("switch current client new url", "url", url)
 	if !l.isInFallbackState {
 		l.isInFallbackState = true
 		l.recoverIfFirstRpcHealth()
@@ -234,6 +234,6 @@ func (l *FallbackClient) recoverIfFirstRpcHealth() {
 		l.lastMinuteFail.Store(0)
 		l.currentIndex = 0
 		l.isInFallbackState = false
-		log.Info("recover current client to first client", "url", l.urlList[0])
+		l.log.Info("recover current client to first client", "url", l.urlList[0])
 	}()
 }

--- a/op-service/client/fallback_client.go
+++ b/op-service/client/fallback_client.go
@@ -71,6 +71,7 @@ func NewFallbackClient(rpc EthClient, urlList []string, log log.Logger, fallback
 		currentIndex:      0,
 		fallbackThreshold: fallbackThreshold,
 		metrics:           m,
+		isClose:           make(chan struct{}),
 	}
 	fallbackClient.currentClient.Store(&rpc)
 	go func() {

--- a/op-service/metrics/balance.go
+++ b/op-service/metrics/balance.go
@@ -2,11 +2,11 @@ package metrics
 
 import (
 	"context"
+	"github.com/ethereum/go-ethereum"
 	"math/big"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/prometheus/client_golang/prometheus"
@@ -25,7 +25,7 @@ func weiToEther(wei *big.Int) float64 {
 // LaunchBalanceMetrics fires off a go rountine that queries the balance of the supplied account & periodically records it
 // to the balance metric of the namespace. The balance of the account is recorded in Ether (not Wei).
 // Cancel the supplied context to shut down the go routine
-func LaunchBalanceMetrics(ctx context.Context, log log.Logger, r *prometheus.Registry, ns string, client *ethclient.Client, account common.Address) {
+func LaunchBalanceMetrics(ctx context.Context, log log.Logger, r *prometheus.Registry, ns string, client ethereum.ChainStateReader, account common.Address) {
 	go func() {
 		balanceGuage := promauto.With(r).NewGauge(prometheus.GaugeOpts{
 			Namespace: ns,

--- a/op-service/txmgr/cli.go
+++ b/op-service/txmgr/cli.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	txmetrics "github.com/ethereum-optimism/optimism/op-service/txmgr/metrics"
 	"math/big"
 	"time"
 
@@ -174,14 +175,14 @@ func ReadCLIConfig(ctx *cli.Context) CLIConfig {
 	}
 }
 
-func NewConfig(cfg CLIConfig, l log.Logger) (Config, error) {
+func NewConfig(cfg CLIConfig, l log.Logger, m txmetrics.TxMetricer) (Config, error) {
 	if err := cfg.Check(); err != nil {
 		return Config{}, fmt.Errorf("invalid config: %w", err)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.NetworkTimeout)
 	defer cancel()
-	l1, err := service_client.DialEthClientWithTimeoutAndFallback(ctx, cfg.L1RPCURL, service_client.DefaultDialTimeout, l, 3)
+	l1, err := service_client.DialEthClientWithTimeoutAndFallback(ctx, cfg.L1RPCURL, service_client.DefaultDialTimeout, l, 3, m)
 	if err != nil {
 		return Config{}, fmt.Errorf("could not dial eth client: %w", err)
 	}

--- a/op-service/txmgr/cli.go
+++ b/op-service/txmgr/cli.go
@@ -182,7 +182,7 @@ func NewConfig(cfg CLIConfig, l log.Logger, m txmetrics.TxMetricer) (Config, err
 
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.NetworkTimeout)
 	defer cancel()
-	l1, err := service_client.DialEthClientWithTimeoutAndFallback(ctx, cfg.L1RPCURL, service_client.DefaultDialTimeout, l, 3, m)
+	l1, err := service_client.DialEthClientWithTimeoutAndFallback(ctx, cfg.L1RPCURL, service_client.DefaultDialTimeout, l, service_client.TxmgrFallbackThreshold, m)
 	if err != nil {
 		return Config{}, fmt.Errorf("could not dial eth client: %w", err)
 	}

--- a/op-service/txmgr/cli.go
+++ b/op-service/txmgr/cli.go
@@ -181,7 +181,7 @@ func NewConfig(cfg CLIConfig, l log.Logger) (Config, error) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.NetworkTimeout)
 	defer cancel()
-	l1, err := service_client.DialEthClientWithTimeoutAndFallback(ctx, cfg.L1RPCURL, service_client.DefaultDialTimeout, l)
+	l1, err := service_client.DialEthClientWithTimeoutAndFallback(ctx, cfg.L1RPCURL, service_client.DefaultDialTimeout, l, 3)
 	if err != nil {
 		return Config{}, fmt.Errorf("could not dial eth client: %w", err)
 	}

--- a/op-service/txmgr/cli.go
+++ b/op-service/txmgr/cli.go
@@ -8,10 +8,10 @@ import (
 	"time"
 
 	opservice "github.com/ethereum-optimism/optimism/op-service"
+	service_client "github.com/ethereum-optimism/optimism/op-service/client"
 	opcrypto "github.com/ethereum-optimism/optimism/op-service/crypto"
 	"github.com/ethereum-optimism/optimism/op-signer/client"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/urfave/cli"
 )
@@ -181,7 +181,7 @@ func NewConfig(cfg CLIConfig, l log.Logger) (Config, error) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.NetworkTimeout)
 	defer cancel()
-	l1, err := ethclient.DialContext(ctx, cfg.L1RPCURL)
+	l1, err := service_client.DialEthClientWithTimeoutAndFallback(ctx, cfg.L1RPCURL, service_client.DefaultDialTimeout, l)
 	if err != nil {
 		return Config{}, fmt.Errorf("could not dial eth client: %w", err)
 	}

--- a/op-service/txmgr/metrics/noop.go
+++ b/op-service/txmgr/metrics/noop.go
@@ -11,3 +11,4 @@ func (*NoopTxMetrics) RecordTxConfirmationLatency(int64) {}
 func (*NoopTxMetrics) TxConfirmed(*types.Receipt)        {}
 func (*NoopTxMetrics) TxPublished(string)                {}
 func (*NoopTxMetrics) RPCError()                         {}
+func (m *NoopTxMetrics) RecordL1UrlSwitchEvt(url string) {}

--- a/op-service/txmgr/metrics/tx_metrics.go
+++ b/op-service/txmgr/metrics/tx_metrics.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/metrics"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
@@ -16,6 +17,7 @@ type TxMetricer interface {
 	TxConfirmed(*types.Receipt)
 	TxPublished(string)
 	RPCError()
+	client.FallbackClientMetricer
 }
 
 type TxMetrics struct {
@@ -30,6 +32,7 @@ type TxMetrics struct {
 	publishEvent       metrics.Event
 	confirmEvent       metrics.EventVec
 	rpcError           prometheus.Counter
+	*client.FallbackClientMetrics
 }
 
 func receiptStatusString(receipt *types.Receipt) string {
@@ -104,6 +107,7 @@ func MakeTxMetrics(ns string, factory metrics.Factory) TxMetrics {
 			Help:      "Temporary: Count of RPC errors (like timeouts) that have occurred",
 			Subsystem: "txmgr",
 		}),
+		FallbackClientMetrics: client.NewFallbackClientMetrics(ns, factory),
 	}
 }
 

--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -94,7 +94,7 @@ type SimpleTxManager struct {
 
 // NewSimpleTxManager initializes a new SimpleTxManager with the passed Config.
 func NewSimpleTxManager(name string, l log.Logger, m metrics.TxMetricer, cfg CLIConfig) (*SimpleTxManager, error) {
-	conf, err := NewConfig(cfg, l)
+	conf, err := NewConfig(cfg, l, m)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Description

The FallbackClient is designed to automatically switch to an alternative L1 endpoint when the current one encounters issues, and revert back once the primary endpoint is functional again.

The core logic operates as follows: When an error occurs, it is recorded until either the error count surpasses a predetermined threshold or the count is reset by a timer that executes once per minute. If the threshold is exceeded within a one-minute span, it suggests the L1 endpoint has become unreliable, prompting the system to select the next address in the L1 URL. A new RPC client is then created to replace the current one. Simultaneously, a separate Goroutine monitors the initial endpoint's health and, when deemed stable, reverts back to its use.

As the clients employed in op-node and op-batcher/op-proposer differ significantly, two distinct fallbackClients have been implemented. The op-node version incorporates additional features such as subscription management and RPC legality checks, resulting in a more complex implementation.

### Rationale

We need to improve stability. Currently, the L1 endpoint is the most unstable point.

### Example

Example of l1 flag after code modification:
```bash
--l1=https://data-seed-prebsc-1-s1.binance.org:8545,https://data-seed-prebsc-2-s2.binance.org:8545,https://data-seed-prebsc-2-s3.binance.org:8545
```

### Changes

- Add fallback client code
- Implant fallback client in op-node, op-batcher, op-proposer related code