### PR TITLE
feat(op-node): receiptsFetchingJob concurrent fetch

### DIFF
--- a/op-node/sources/l1_client.go
+++ b/op-node/sources/l1_client.go
@@ -37,7 +37,7 @@ func L1ClientDefaultConfig(config *rollup.Config, trustRPC bool, kind RPCProvide
 			HeadersCacheSize:      span,
 			PayloadsCacheSize:     span,
 			MaxRequestsPerBatch:   20, // TODO: tune batch param
-			MaxConcurrentRequests: 10,
+			MaxConcurrentRequests: 20,
 			TrustRPC:              trustRPC,
 			MustBePostMerge:       false,
 			RPCProviderKind:       kind,

--- a/op-node/sources/receipts.go
+++ b/op-node/sources/receipts.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
 	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -395,9 +396,43 @@ func (job *receiptsFetchingJob) runFetcher(ctx context.Context) error {
 			job.maxBatchSize,
 		)
 	}
-	// Fetch all receipts
+
+	if len(job.txHashes) > job.maxBatchSize {
+		// if we have more than the max batch size, we can do concurrent fetching
+		err2 := job.concurrentFetch(ctx)
+		if err2 != nil {
+			return err2
+		}
+	} else {
+		// otherwise, we can do sequential fetching
+		for {
+			if err := job.fetcher.Fetch(ctx); err == io.EOF {
+				break
+			} else if err != nil {
+				return err
+			}
+		}
+	}
+
+	result, err := job.fetcher.Result()
+	if err != nil { // errors if results are not available yet, should never happen.
+		return err
+	}
+	if err := validateReceipts(job.block, job.receiptHash, job.txHashes, result); err != nil {
+		job.fetcher.Reset() // if results are fetched but invalid, try restart all the fetching to try and get valid data.
+		return err
+	}
+	// Remember the result, and don't keep the fetcher and tx hashes around for longer than needed
+	job.result = result
+	job.fetcher = nil
+	job.txHashes = nil
+	return nil
+}
+
+func (job *receiptsFetchingJob) concurrentFetch(ctx context.Context) error {
 	var wg sync.WaitGroup
-	concurrentRequests := job.maxConcurrentRequests
+	suggestConcurrent := math.Ceil(float64(len(job.txHashes)) / float64(job.maxBatchSize))
+	concurrentRequests := int(math.Min(suggestConcurrent, float64(job.maxConcurrentRequests)))
 	wg.Add(concurrentRequests)
 	errs := make(chan error, concurrentRequests)
 	for i := 0; i < concurrentRequests; i++ {
@@ -419,19 +454,6 @@ func (job *receiptsFetchingJob) runFetcher(ctx context.Context) error {
 			return callErr
 		}
 	}
-
-	result, err := job.fetcher.Result()
-	if err != nil { // errors if results are not available yet, should never happen.
-		return err
-	}
-	if err := validateReceipts(job.block, job.receiptHash, job.txHashes, result); err != nil {
-		job.fetcher.Reset() // if results are fetched but invalid, try restart all the fetching to try and get valid data.
-		return err
-	}
-	// Remember the result, and don't keep the fetcher and tx hashes around for longer than needed
-	job.result = result
-	job.fetcher = nil
-	job.txHashes = nil
 	return nil
 }
 

--- a/op-node/sources/receipts.go
+++ b/op-node/sources/receipts.go
@@ -397,21 +397,9 @@ func (job *receiptsFetchingJob) runFetcher(ctx context.Context) error {
 		)
 	}
 
-	if len(job.txHashes) > job.maxBatchSize {
-		// if we have more than the max batch size, we can do concurrent fetching
-		err2 := job.concurrentFetch(ctx)
-		if err2 != nil {
-			return err2
-		}
-	} else {
-		// otherwise, we can do sequential fetching
-		for {
-			if err := job.fetcher.Fetch(ctx); err == io.EOF {
-				break
-			} else if err != nil {
-				return err
-			}
-		}
+	err2 := job.concurrentFetch(ctx)
+	if err2 != nil {
+		return err2
 	}
 
 	result, err := job.fetcher.Result()


### PR DESCRIPTION
The current logic of receiptsFetchingJob is a serial fetch, modifying it to a concurrent fetch can significantly improve performance