### PR TITLE
fix(op-e2e): fallback to not use bsc specific method eth_getFinalizedBlock

### DIFF
--- a/op-node/sources/l1_client.go
+++ b/op-node/sources/l1_client.go
@@ -76,6 +76,10 @@ func NewL1Client(client client.RPC, log log.Logger, metrics caching.Metrics, con
 // Notice, we cannot cache a block reference by label because labels are not guaranteed to be unique.
 func (s *L1Client) L1BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L1BlockRef, error) {
 	info, err := s.BSCInfoByLabel(ctx, label)
+	if err != nil && label == eth.Finalized {
+		// op-e2e not support bsc as L1 currently, so fallback to not use bsc specific method eth_getFinalizedBlock
+		info, err = s.InfoByLabel(ctx, label)
+	}
 	if err != nil {
 		// Both geth and erigon like to serve non-standard errors for the safe and finalized heads, correct that.
 		// This happens when the chain just started and nothing is marked as safe/finalized yet.

--- a/op-node/sources/l1_client.go
+++ b/op-node/sources/l1_client.go
@@ -76,7 +76,7 @@ func NewL1Client(client client.RPC, log log.Logger, metrics caching.Metrics, con
 // Notice, we cannot cache a block reference by label because labels are not guaranteed to be unique.
 func (s *L1Client) L1BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L1BlockRef, error) {
 	info, err := s.BSCInfoByLabel(ctx, label)
-	if err != nil && label == eth.Finalized {
+	if label == eth.Finalized && err != nil && strings.Contains(err.Error(), "eth_getFinalizedBlock does not exist") {
 		// op-e2e not support bsc as L1 currently, so fallback to not use bsc specific method eth_getFinalizedBlock
 		info, err = s.InfoByLabel(ctx, label)
 	}


### PR DESCRIPTION
### Description

Fix op-e2e test ci

### Rationale

currently op-e2e use[ go-ethereum in memory](https://github.com/bnb-chain/opbnb/blob/b1c385832be8cbd7f1598122de22fbc594fdfaca/op-e2e/actions/l1_replica.go#L33) as L1, so bsc specific rpc method eth_getFinalizedBlock is not supported
this pr fallback to not use eth_getFinalizedBlock if it's not supported

### Example

### Changes
L1Client fallback to not use eth_getFinalizedBlock if it's not supported
