### PR TITLE
fix(ci): trigger docker image build with tags

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -3,7 +3,7 @@ name: DockerImage build and push
 on:
   workflow_dispatch:
   push:
-    tags:
+    tags: '*'
     branches:
       - develop
       - main


### PR DESCRIPTION
### Description

Fix the issue where Docker image builds are not triggered by tags.

### Rationale

NA

### Example

NA

### Changes

NA