### PR TITLE
chore(ci): randomly assign 2 reviewers with bot

### DIFF
--- a/.github/workflows/reviewer.yml
+++ b/.github/workflows/reviewer.yml
@@ -1,0 +1,14 @@
+name: Review Assign
+
+on:
+  pull_request_target:
+    types: [opened, ready_for_review]
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: hkusu/review-assign-action@v1
+        with:
+          reviewers: ${{ vars.REVIEWERS }}
+          max-num-of-reviewers: 2


### PR DESCRIPTION
### Description

Implemented a feature to automatically assign two reviewers to a PR using a bot.

### Rationale

This automation streamlines the review process, ensuring that each PR is reviewed by at least two team members, thereby maintaining code quality and consistency.

### Example

Upon PR submission, the bot automatically assigns two reviewers from the team.

### Changes

Notable changes:
* Created a script for the bot to randomly select and assign two reviewers to a PR.
* Integrated the bot script with the existing CI/CD pipeline.
