### PR TITLE
ci: execute op-e2e-http-test and op-e2e-ws-test serially

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,7 @@ jobs:
 
   op-e2e-ws-test:
     runs-on: ubuntu-latest
-    needs: [op-node-test, op-batcher-test, op-proposer-test]
+    needs: [op-node-test, op-batcher-test, op-proposer-test, op-e2e-http-test]
 
     steps:
       - name: Check out code


### PR DESCRIPTION
### Description

execute op-e2e-http-test and op-e2e-ws-test serially

### Rationale

These two CI sometimes fail because the CI machine specifications is low. We need to let CI execute serially to increase the success rate of ci execution.

### Example

none

### Changes

- execute op-e2e-http-test and op-e2e-ws-test serially
