### PR TITLE
feat: support persist active api

### DIFF
--- a/op-batcher/metrics/metrics.go
+++ b/op-batcher/metrics/metrics.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/prometheus/client_golang/prometheus"
 

--- a/op-batcher/metrics/metrics.go
+++ b/op-batcher/metrics/metrics.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/prometheus/client_golang/prometheus"
 

--- a/op-e2e/actions/l2_verifier.go
+++ b/op-e2e/actions/l2_verifier.go
@@ -122,6 +122,10 @@ func (s *l2VerifierBackend) StopSequencer(ctx context.Context) (common.Hash, err
 	return common.Hash{}, errors.New("stopping the L2Verifier sequencer is not supported")
 }
 
+func (s *l2VerifierBackend) SequencerActive(ctx context.Context) (bool, error) {
+	return false, nil
+}
+
 func (s *L2Verifier) L2Finalized() eth.L2BlockRef {
 	return s.derivation.Finalized()
 }

--- a/op-e2e/setup.go
+++ b/op-e2e/setup.go
@@ -170,6 +170,7 @@ func DefaultSystemConfig(t *testing.T) SystemConfig {
 					EnableAdmin: true,
 				},
 				L1EpochPollInterval: time.Second * 4,
+				ConfigPersistence:   &rollupNode.DisabledConfigPersistence{},
 			},
 			"verifier": {
 				Driver: driver.Config{
@@ -178,6 +179,7 @@ func DefaultSystemConfig(t *testing.T) SystemConfig {
 					SequencerEnabled:   false,
 				},
 				L1EpochPollInterval: time.Second * 4,
+				ConfigPersistence:   &rollupNode.DisabledConfigPersistence{},
 			},
 		},
 		Loggers: map[string]log.Logger{
@@ -546,6 +548,9 @@ func (cfg SystemConfig) Start(_opts ...SystemConfigOption) (*System, error) {
 		nodeConfig := cfg.Nodes[name]
 		c := *nodeConfig // copy
 		c.Rollup = makeRollupConfig()
+		if err := c.LoadPersisted(cfg.Loggers[name]); err != nil {
+			return nil, err
+		}
 
 		if p, ok := p2pNodes[name]; ok {
 			c.P2P = p

--- a/op-e2e/system_adminrpc_test.go
+++ b/op-e2e/system_adminrpc_test.go
@@ -1,0 +1,177 @@
+package op_e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-node/client"
+	"github.com/ethereum-optimism/optimism/op-node/node"
+	"github.com/ethereum-optimism/optimism/op-node/sources"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStopStartSequencer(t *testing.T) {
+	InitParallel(t)
+
+	cfg := DefaultSystemConfig(t)
+	sys, err := cfg.Start()
+	require.Nil(t, err, "Error starting up system")
+	defer sys.Close()
+
+	l2Seq := sys.Clients["sequencer"]
+	rollupNode := sys.RollupNodes["sequencer"]
+
+	nodeRPC, err := rpc.DialContext(context.Background(), rollupNode.HTTPEndpoint())
+	require.Nil(t, err, "Error dialing node")
+	rollupClient := sources.NewRollupClient(client.NewBaseRPCClient(nodeRPC))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	active, err := rollupClient.SequencerActive(ctx)
+	require.NoError(t, err)
+	require.True(t, active, "sequencer should be active")
+
+	blockBefore := latestBlock(t, l2Seq)
+	time.Sleep(time.Duration(cfg.DeployConfig.L2BlockTime+1) * time.Second)
+	blockAfter := latestBlock(t, l2Seq)
+	require.Greaterf(t, blockAfter, blockBefore, "Chain did not advance")
+
+	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	blockHash, err := rollupClient.StopSequencer(ctx)
+	require.Nil(t, err, "Error stopping sequencer")
+
+	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	active, err = rollupClient.SequencerActive(ctx)
+	require.NoError(t, err)
+	require.False(t, active, "sequencer should be inactive")
+
+	blockBefore = latestBlock(t, l2Seq)
+	time.Sleep(time.Duration(cfg.DeployConfig.L2BlockTime+1) * time.Second)
+	blockAfter = latestBlock(t, l2Seq)
+	require.Equal(t, blockAfter, blockBefore, "Chain advanced after stopping sequencer")
+
+	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err = rollupClient.StartSequencer(ctx, blockHash)
+	require.Nil(t, err, "Error starting sequencer")
+
+	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	active, err = rollupClient.SequencerActive(ctx)
+	require.NoError(t, err)
+	require.True(t, active, "sequencer should be active again")
+
+	blockBefore = latestBlock(t, l2Seq)
+	time.Sleep(time.Duration(cfg.DeployConfig.L2BlockTime+1) * time.Second)
+	blockAfter = latestBlock(t, l2Seq)
+	require.Greater(t, blockAfter, blockBefore, "Chain did not advance after starting sequencer")
+}
+
+func TestPersistSequencerStateWhenChanged(t *testing.T) {
+	InitParallel(t)
+	ctx := context.Background()
+	dir := t.TempDir()
+	stateFile := dir + "/state.json"
+
+	cfg := DefaultSystemConfig(t)
+	// We don't need a verifier - just the sequencer is enough
+	delete(cfg.Nodes, "verifier")
+	cfg.Nodes["sequencer"].ConfigPersistence = node.NewConfigPersistence(stateFile)
+
+	sys, err := cfg.Start()
+	require.NoError(t, err)
+	defer sys.Close()
+
+	assertPersistedSequencerState(t, stateFile, node.StateStarted)
+
+	rollupRPCClient, err := rpc.DialContext(ctx, sys.RollupNodes["sequencer"].HTTPEndpoint())
+	require.Nil(t, err)
+	rollupClient := sources.NewRollupClient(client.NewBaseRPCClient(rollupRPCClient))
+
+	err = rollupClient.StartSequencer(ctx, common.Hash{0xaa})
+	require.ErrorContains(t, err, "sequencer already running")
+
+	head, err := rollupClient.StopSequencer(ctx)
+	require.NoError(t, err)
+	require.NotEqual(t, common.Hash{}, head)
+	assertPersistedSequencerState(t, stateFile, node.StateStopped)
+}
+
+func TestLoadSequencerStateOnStarted_Stopped(t *testing.T) {
+	InitParallel(t)
+	ctx := context.Background()
+	dir := t.TempDir()
+	stateFile := dir + "/state.json"
+
+	// Prepare the persisted state file with sequencer stopped
+	configReader := node.NewConfigPersistence(stateFile)
+	require.NoError(t, configReader.SequencerStopped())
+
+	cfg := DefaultSystemConfig(t)
+	// We don't need a verifier - just the sequencer is enough
+	delete(cfg.Nodes, "verifier")
+	seqCfg := cfg.Nodes["sequencer"]
+	seqCfg.ConfigPersistence = node.NewConfigPersistence(stateFile)
+
+	sys, err := cfg.Start()
+	require.NoError(t, err)
+	defer sys.Close()
+
+	rollupRPCClient, err := rpc.DialContext(ctx, sys.RollupNodes["sequencer"].HTTPEndpoint())
+	require.Nil(t, err)
+	rollupClient := sources.NewRollupClient(client.NewBaseRPCClient(rollupRPCClient))
+
+	// Still persisted as stopped after startup
+	assertPersistedSequencerState(t, stateFile, node.StateStopped)
+
+	// Sequencer is really stopped
+	_, err = rollupClient.StopSequencer(ctx)
+	require.ErrorContains(t, err, "sequencer not running")
+	assertPersistedSequencerState(t, stateFile, node.StateStopped)
+}
+
+func TestLoadSequencerStateOnStarted_Started(t *testing.T) {
+	InitParallel(t)
+	ctx := context.Background()
+	dir := t.TempDir()
+	stateFile := dir + "/state.json"
+
+	// Prepare the persisted state file with sequencer stopped
+	configReader := node.NewConfigPersistence(stateFile)
+	require.NoError(t, configReader.SequencerStarted())
+
+	cfg := DefaultSystemConfig(t)
+	// We don't need a verifier - just the sequencer is enough
+	delete(cfg.Nodes, "verifier")
+	seqCfg := cfg.Nodes["sequencer"]
+	seqCfg.Driver.SequencerStopped = true
+	seqCfg.ConfigPersistence = node.NewConfigPersistence(stateFile)
+
+	sys, err := cfg.Start()
+	require.NoError(t, err)
+	defer sys.Close()
+
+	rollupRPCClient, err := rpc.DialContext(ctx, sys.RollupNodes["sequencer"].HTTPEndpoint())
+	require.Nil(t, err)
+	rollupClient := sources.NewRollupClient(client.NewBaseRPCClient(rollupRPCClient))
+
+	// Still persisted as stopped after startup
+	assertPersistedSequencerState(t, stateFile, node.StateStarted)
+
+	// Sequencer is really stopped
+	err = rollupClient.StartSequencer(ctx, common.Hash{})
+	require.ErrorContains(t, err, "sequencer already running")
+	assertPersistedSequencerState(t, stateFile, node.StateStarted)
+}
+
+func assertPersistedSequencerState(t *testing.T, stateFile string, expected node.RunningState) {
+	configReader := node.NewConfigPersistence(stateFile)
+	state, err := configReader.SequencerState()
+	require.NoError(t, err)
+	require.Equalf(t, expected, state, "expected sequencer state %v but was %v", expected, state)
+}

--- a/op-e2e/system_test.go
+++ b/op-e2e/system_test.go
@@ -1251,47 +1251,6 @@ func TestFees(t *testing.T) {
 	require.Equal(t, balanceDiff, totalFee, "balances should add up")
 }
 
-func TestStopStartSequencer(t *testing.T) {
-	InitParallel(t)
-
-	cfg := DefaultSystemConfig(t)
-	sys, err := cfg.Start()
-	require.Nil(t, err, "Error starting up system")
-	defer sys.Close()
-
-	l2Seq := sys.Clients["sequencer"]
-	rollupNode := sys.RollupNodes["sequencer"]
-
-	nodeRPC, err := rpc.DialContext(context.Background(), rollupNode.HTTPEndpoint())
-	require.Nil(t, err, "Error dialing node")
-
-	blockBefore := latestBlock(t, l2Seq)
-	time.Sleep(time.Duration(cfg.DeployConfig.L2BlockTime+1) * time.Second)
-	blockAfter := latestBlock(t, l2Seq)
-	require.Greaterf(t, blockAfter, blockBefore, "Chain did not advance")
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	blockHash := common.Hash{}
-	err = nodeRPC.CallContext(ctx, &blockHash, "admin_stopSequencer")
-	require.Nil(t, err, "Error stopping sequencer")
-
-	blockBefore = latestBlock(t, l2Seq)
-	time.Sleep(time.Duration(cfg.DeployConfig.L2BlockTime+1) * time.Second)
-	blockAfter = latestBlock(t, l2Seq)
-	require.Equal(t, blockAfter, blockBefore, "Chain advanced after stopping sequencer")
-
-	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	err = nodeRPC.CallContext(ctx, nil, "admin_startSequencer", blockHash)
-	require.Nil(t, err, "Error starting sequencer")
-
-	blockBefore = latestBlock(t, l2Seq)
-	time.Sleep(time.Duration(cfg.DeployConfig.L2BlockTime+1) * time.Second)
-	blockAfter = latestBlock(t, l2Seq)
-	require.Greater(t, blockAfter, blockBefore, "Chain did not advance after starting sequencer")
-}
-
 func TestStopStartBatcher(t *testing.T) {
 	InitParallel(t)
 

--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -59,6 +59,11 @@ var (
 		Usage:  "Enable the admin API (experimental)",
 		EnvVar: prefixEnvVar("RPC_ENABLE_ADMIN"),
 	}
+	RPCAdminPersistence = cli.StringFlag{
+		Name:   "rpc.admin-state",
+		Usage:  "File path used to persist state changes made via the admin API so they persist across restarts. Disabled if not set.",
+		EnvVar: prefixEnvVar("RPC_ADMIN_STATE"),
+	}
 
 	/* Optional Flags */
 	L1TrustRPC = cli.BoolFlag{
@@ -253,6 +258,7 @@ var optionalFlags = []cli.Flag{
 	SequencerL1Confs,
 	L1EpochPollIntervalFlag,
 	RPCEnableAdmin,
+	RPCAdminPersistence,
 	MetricsEnabledFlag,
 	MetricsAddrFlag,
 	MetricsPortFlag,

--- a/op-node/node/api.go
+++ b/op-node/node/api.go
@@ -28,6 +28,7 @@ type driverClient interface {
 	ResetDerivationPipeline(context.Context) error
 	StartSequencer(ctx context.Context, blockHash common.Hash) error
 	StopSequencer(context.Context) (common.Hash, error)
+	SequencerActive(context.Context) (bool, error)
 }
 
 type rpcMetrics interface {
@@ -63,6 +64,12 @@ func (n *adminAPI) StopSequencer(ctx context.Context) (common.Hash, error) {
 	recordDur := n.m.RecordRPCServerRequest("admin_stopSequencer")
 	defer recordDur()
 	return n.dr.StopSequencer(ctx)
+}
+
+func (n *adminAPI) SequencerActive(ctx context.Context) (bool, error) {
+	recordDur := n.m.RecordRPCServerRequest("admin_sequencerActive")
+	defer recordDur()
+	return n.dr.SequencerActive(ctx)
 }
 
 type nodeAPI struct {

--- a/op-node/node/config.go
+++ b/op-node/node/config.go
@@ -6,11 +6,13 @@ import (
 	"math"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-node/flags"
 	"github.com/ethereum-optimism/optimism/op-node/p2p"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/driver"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	oppprof "github.com/ethereum-optimism/optimism/op-service/pprof"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 type Config struct {
@@ -36,6 +38,8 @@ type Config struct {
 
 	// Used to poll the L1 for new finalized or safe blocks
 	L1EpochPollInterval time.Duration
+
+	ConfigPersistence ConfigPersistence
 
 	// Optional
 	Tracer    Tracer
@@ -76,6 +80,24 @@ type HeartbeatConfig struct {
 	Enabled bool
 	Moniker string
 	URL     string
+}
+
+func (cfg *Config) LoadPersisted(log log.Logger) error {
+	if !cfg.Driver.SequencerEnabled {
+		return nil
+	}
+	if state, err := cfg.ConfigPersistence.SequencerState(); err != nil {
+		return err
+	} else if state != StateUnset {
+		stopped := state == StateStopped
+		if stopped != cfg.Driver.SequencerStopped {
+			log.Warn(fmt.Sprintf("Overriding %v with persisted state", flags.SequencerStoppedFlag.Name), "stopped", stopped)
+		}
+		cfg.Driver.SequencerStopped = stopped
+	} else {
+		log.Info("No persisted sequencer state loaded")
+	}
+	return nil
 }
 
 // Check verifies that the given configuration makes sense

--- a/op-node/node/config_persistence.go
+++ b/op-node/node/config_persistence.go
@@ -1,0 +1,142 @@
+package node
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+type RunningState int
+
+const (
+	StateUnset RunningState = iota
+	StateStarted
+	StateStopped
+)
+
+type persistedState struct {
+	SequencerStarted *bool `json:"sequencerStarted,omitempty"`
+}
+
+type ConfigPersistence interface {
+	SequencerStarted() error
+	SequencerStopped() error
+	SequencerState() (RunningState, error)
+}
+
+var _ ConfigPersistence = (*ActiveConfigPersistence)(nil)
+var _ ConfigPersistence = DisabledConfigPersistence{}
+
+type ActiveConfigPersistence struct {
+	lock sync.Mutex
+	file string
+}
+
+func NewConfigPersistence(file string) *ActiveConfigPersistence {
+	return &ActiveConfigPersistence{file: file}
+}
+
+func (p *ActiveConfigPersistence) SequencerStarted() error {
+	return p.persist(true)
+}
+
+func (p *ActiveConfigPersistence) SequencerStopped() error {
+	return p.persist(false)
+}
+
+// persist writes the new config state to the file as safely as possible.
+// It uses sync to ensure the data is actually persisted to disk and initially writes to a temp file
+// before renaming it into place. On UNIX systems this rename is typically atomic, ensuring the
+// actual file isn't corrupted if IO errors occur during writing.
+func (p *ActiveConfigPersistence) persist(sequencerStarted bool) error {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	data, err := json.Marshal(persistedState{SequencerStarted: &sequencerStarted})
+	if err != nil {
+		return fmt.Errorf("marshall new config: %w", err)
+	}
+	dir := filepath.Dir(p.file)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("create config dir (%v): %w", p.file, err)
+	}
+	// Write the new content to a temp file first, then rename into place
+	// Avoids corrupting the content if the disk is full or there are IO errors
+	tmpFile := p.file + ".tmp"
+	file, err := os.OpenFile(tmpFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return fmt.Errorf("open file (%v) for writing: %w", tmpFile, err)
+	}
+	defer file.Close() // Ensure file is closed even if write or sync fails
+	if _, err = file.Write(data); err != nil {
+		return fmt.Errorf("write new config to temp file (%v): %w", tmpFile, err)
+	}
+	if err := file.Sync(); err != nil {
+		return fmt.Errorf("sync new config temp file (%v): %w", tmpFile, err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close new config temp file (%v): %w", tmpFile, err)
+	}
+	// Rename to replace the previous file
+	if err := os.Rename(tmpFile, p.file); err != nil {
+		return fmt.Errorf("rename temp config file to final destination: %w", err)
+	}
+	return nil
+}
+
+func (p *ActiveConfigPersistence) SequencerState() (RunningState, error) {
+	config, err := p.read()
+	if err != nil {
+		return StateUnset, err
+	}
+
+	if config.SequencerStarted == nil {
+		return StateUnset, nil
+	} else if *config.SequencerStarted {
+		return StateStarted, nil
+	} else {
+		return StateStopped, nil
+	}
+}
+
+func (p *ActiveConfigPersistence) read() (persistedState, error) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	data, err := os.ReadFile(p.file)
+	if errors.Is(err, os.ErrNotExist) {
+		// persistedState.SequencerStarted == nil: SequencerState() will return StateUnset if no state is found
+		return persistedState{}, nil
+	} else if err != nil {
+		return persistedState{}, fmt.Errorf("read config file (%v): %w", p.file, err)
+	}
+	var config persistedState
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err = dec.Decode(&config); err != nil {
+		return persistedState{}, fmt.Errorf("invalid config file (%v): %w", p.file, err)
+	}
+	if config.SequencerStarted == nil {
+		return persistedState{}, fmt.Errorf("missing sequencerStarted value in config file (%v)", p.file)
+	}
+	return config, nil
+}
+
+// DisabledConfigPersistence provides an implementation of config persistence
+// that does not persist anything and reports unset for all values
+type DisabledConfigPersistence struct {
+}
+
+func (d DisabledConfigPersistence) SequencerState() (RunningState, error) {
+	return StateUnset, nil
+}
+
+func (d DisabledConfigPersistence) SequencerStarted() error {
+	return nil
+}
+
+func (d DisabledConfigPersistence) SequencerStopped() error {
+	return nil
+}

--- a/op-node/node/config_persistence_test.go
+++ b/op-node/node/config_persistence_test.go
@@ -1,0 +1,96 @@
+package node
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestActive(t *testing.T) {
+	create := func() *ActiveConfigPersistence {
+		dir := t.TempDir()
+		config := NewConfigPersistence(dir + "/state")
+		return config
+	}
+
+	t.Run("SequencerStateUnsetWhenFileDoesNotExist", func(t *testing.T) {
+		config := create()
+		state, err := config.SequencerState()
+		require.NoError(t, err)
+		require.Equal(t, StateUnset, state)
+	})
+
+	t.Run("PersistSequencerStarted", func(t *testing.T) {
+		config1 := create()
+		require.NoError(t, config1.SequencerStarted())
+		state, err := config1.SequencerState()
+		require.NoError(t, err)
+		require.Equal(t, StateStarted, state)
+
+		config2 := NewConfigPersistence(config1.file)
+		state, err = config2.SequencerState()
+		require.NoError(t, err)
+		require.Equal(t, StateStarted, state)
+	})
+
+	t.Run("PersistSequencerStopped", func(t *testing.T) {
+		config1 := create()
+		require.NoError(t, config1.SequencerStopped())
+		state, err := config1.SequencerState()
+		require.NoError(t, err)
+		require.Equal(t, StateStopped, state)
+
+		config2 := NewConfigPersistence(config1.file)
+		state, err = config2.SequencerState()
+		require.NoError(t, err)
+		require.Equal(t, StateStopped, state)
+	})
+
+	t.Run("PersistMultipleChanges", func(t *testing.T) {
+		config := create()
+		require.NoError(t, config.SequencerStarted())
+		state, err := config.SequencerState()
+		require.NoError(t, err)
+		require.Equal(t, StateStarted, state)
+
+		require.NoError(t, config.SequencerStopped())
+		state, err = config.SequencerState()
+		require.NoError(t, err)
+		require.Equal(t, StateStopped, state)
+	})
+
+	t.Run("CreateParentDirs", func(t *testing.T) {
+		dir := t.TempDir()
+		config := NewConfigPersistence(dir + "/some/dir/state")
+
+		// Should be unset before file exists
+		state, err := config.SequencerState()
+		require.NoError(t, err)
+		require.Equal(t, StateUnset, state)
+		require.NoFileExists(t, config.file)
+
+		// Should create directories when updating
+		require.NoError(t, config.SequencerStarted())
+		require.FileExists(t, config.file)
+		state, err = config.SequencerState()
+		require.NoError(t, err)
+		require.Equal(t, StateStarted, state)
+	})
+}
+
+func TestDisabledConfigPersistence_AlwaysUnset(t *testing.T) {
+	config := DisabledConfigPersistence{}
+	state, err := config.SequencerState()
+	require.NoError(t, err)
+	require.Equal(t, StateUnset, state)
+
+	require.NoError(t, config.SequencerStarted())
+	state, err = config.SequencerState()
+	require.NoError(t, err)
+	require.Equal(t, StateUnset, state)
+
+	require.NoError(t, config.SequencerStopped())
+	state, err = config.SequencerState()
+	require.NoError(t, err)
+	require.Equal(t, StateUnset, state)
+}

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -206,7 +206,7 @@ func (n *OpNode) initL2(ctx context.Context, cfg *Config, snapshotLog log.Logger
 		return err
 	}
 
-	n.l2Driver = driver.NewDriver(&cfg.Driver, &cfg.Rollup, n.l2Source, n.l1Source, n, n, n.log, snapshotLog, n.metrics, &cfg.Sync)
+	n.l2Driver = driver.NewDriver(&cfg.Driver, &cfg.Rollup, n.l2Source, n.l1Source, n, n, n.log, snapshotLog, n.metrics, cfg.ConfigPersistence, &cfg.Sync)
 
 	return nil
 }

--- a/op-node/node/server_test.go
+++ b/op-node/node/server_test.go
@@ -228,3 +228,7 @@ func (c *mockDriverClient) StartSequencer(ctx context.Context, blockHash common.
 func (c *mockDriverClient) StopSequencer(ctx context.Context) (common.Hash, error) {
 	return c.Mock.MethodCalled("StopSequencer").Get(0).(common.Hash), nil
 }
+
+func (c *mockDriverClient) SequencerActive(ctx context.Context) (bool, error) {
+	return c.Mock.MethodCalled("SequencerActive").Get(0).(bool), nil
+}

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -104,8 +104,13 @@ type AltSync interface {
 	RequestL2Range(ctx context.Context, start, end eth.L2BlockRef) error
 }
 
+type SequencerStateListener interface {
+	SequencerStarted() error
+	SequencerStopped() error
+}
+
 // NewDriver composes an events handler that tracks L1 state, triggers L2 derivation, and optionally sequences new L2 blocks.
-func NewDriver(driverCfg *Config, cfg *rollup.Config, l2 L2Chain, l1 L1Chain, altSync AltSync, network Network, log log.Logger, snapshotLog log.Logger, metrics Metrics, syncCfg *sync.Config) *Driver {
+func NewDriver(driverCfg *Config, cfg *rollup.Config, l2 L2Chain, l1 L1Chain, altSync AltSync, network Network, log log.Logger, snapshotLog log.Logger, metrics Metrics, sequencerStateListener SequencerStateListener, syncCfg *sync.Config) *Driver {
 	l1 = NewMeteredL1Fetcher(l1, metrics)
 	l1State := NewL1State(log, metrics)
 	sequencerConfDepth := NewConfDepth(driverCfg.SequencerConfDepth, l1State.L1Head, l1)
@@ -124,6 +129,8 @@ func NewDriver(driverCfg *Config, cfg *rollup.Config, l2 L2Chain, l1 L1Chain, al
 		forceReset:       make(chan chan struct{}, 10),
 		startSequencer:   make(chan hashAndErrorChannel, 10),
 		stopSequencer:    make(chan chan hashAndError, 10),
+		sequencerActive:  make(chan chan bool, 10),
+		sequencerNotifs:  sequencerStateListener,
 		config:           cfg,
 		driverConfig:     driverCfg,
 		done:             make(chan struct{}),

--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -47,6 +47,14 @@ type Driver struct {
 	// It tells the caller that the sequencer stopped by returning the latest sequenced L2 block hash.
 	stopSequencer chan chan hashAndError
 
+	// Upon receiving a channel in this channel, the current sequencer status is queried.
+	// It tells the caller the status by outputting a boolean to the provided channel:
+	// true when the sequencer is active, false when it is not.
+	sequencerActive chan chan bool
+
+	// sequencerNotifs is notified when the sequencer is started or stopped
+	sequencerNotifs SequencerStateListener
+
 	// Rollup config: rollup chain configuration
 	config *rollup.Config
 
@@ -87,6 +95,21 @@ type Driver struct {
 // The loop will have been started iff err is not nil.
 func (s *Driver) Start() error {
 	s.derivation.Reset()
+
+	log.Info("Starting driver", "sequencerEnabled", s.driverConfig.SequencerEnabled, "sequencerStopped", s.driverConfig.SequencerStopped)
+	if s.driverConfig.SequencerEnabled {
+		// Notify the initial sequencer state
+		// This ensures persistence can write the state correctly and that the state file exists
+		var err error
+		if s.driverConfig.SequencerStopped {
+			err = s.sequencerNotifs.SequencerStopped()
+		} else {
+			err = s.sequencerNotifs.SequencerStarted()
+		}
+		if err != nil {
+			return fmt.Errorf("persist initial sequencer state: %w", err)
+		}
+	}
 
 	s.wg.Add(1)
 	go s.eventLoop()
@@ -371,6 +394,10 @@ func (s *Driver) eventLoop() {
 			} else if !bytes.Equal(unsafeHead[:], resp.hash[:]) {
 				resp.err <- fmt.Errorf("block hash does not match: head %s, received %s", unsafeHead.String(), resp.hash.String())
 			} else {
+				if err := s.sequencerNotifs.SequencerStarted(); err != nil {
+					resp.err <- fmt.Errorf("sequencer start notification: %w", err)
+					continue
+				}
 				s.log.Info("Sequencer has been started")
 				s.driverConfig.SequencerStopped = false
 				close(resp.err)
@@ -380,10 +407,16 @@ func (s *Driver) eventLoop() {
 			if s.driverConfig.SequencerStopped {
 				respCh <- hashAndError{err: errors.New("sequencer not running")}
 			} else {
+				if err := s.sequencerNotifs.SequencerStopped(); err != nil {
+					respCh <- hashAndError{err: fmt.Errorf("sequencer start notification: %w", err)}
+					continue
+				}
 				s.log.Warn("Sequencer has been stopped")
 				s.driverConfig.SequencerStopped = true
 				respCh <- hashAndError{hash: s.derivation.UnsafeL2Head().Hash}
 			}
+		case respCh := <-s.sequencerActive:
+			respCh <- !s.driverConfig.SequencerStopped
 		case <-s.done:
 			return
 		}
@@ -443,6 +476,24 @@ func (s *Driver) StopSequencer(ctx context.Context) (common.Hash, error) {
 			return common.Hash{}, ctx.Err()
 		case he := <-respCh:
 			return he.hash, he.err
+		}
+	}
+}
+
+func (s *Driver) SequencerActive(ctx context.Context) (bool, error) {
+	if !s.driverConfig.SequencerEnabled {
+		return false, nil
+	}
+	respCh := make(chan bool, 1)
+	select {
+	case <-ctx.Done():
+		return false, ctx.Err()
+	case s.sequencerActive <- respCh:
+		select {
+		case <-ctx.Done():
+			return false, ctx.Err()
+		case active := <-respCh:
+			return active, nil
 		}
 	}
 }

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -92,7 +92,7 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*node.Config, error) {
 			URL:     ctx.GlobalString(flags.HeartbeatURLFlag.Name),
 		},
 		ConfigPersistence: configPersistence,
-		Sync: *syncConfig,
+		Sync:              *syncConfig,
 	}
 
 	if err := cfg.LoadPersisted(log); err != nil {

--- a/op-node/sources/rollupclient.go
+++ b/op-node/sources/rollupclient.go
@@ -3,6 +3,7 @@ package sources
 import (
 	"context"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 
 	"github.com/ethereum-optimism/optimism/op-node/client"
@@ -40,4 +41,20 @@ func (r *RollupClient) Version(ctx context.Context) (string, error) {
 	var output string
 	err := r.rpc.CallContext(ctx, &output, "optimism_version")
 	return output, err
+}
+
+func (r *RollupClient) StartSequencer(ctx context.Context, unsafeHead common.Hash) error {
+	return r.rpc.CallContext(ctx, nil, "admin_startSequencer", unsafeHead)
+}
+
+func (r *RollupClient) StopSequencer(ctx context.Context) (common.Hash, error) {
+	var result common.Hash
+	err := r.rpc.CallContext(ctx, &result, "admin_stopSequencer")
+	return result, err
+}
+
+func (r *RollupClient) SequencerActive(ctx context.Context) (bool, error) {
+	var result bool
+	err := r.rpc.CallContext(ctx, &result, "admin_sequencerActive")
+	return result, err
 }


### PR DESCRIPTION
### Description

Merge a previous PR #24 to develop branch.

### Rationale

The previous pull request, #24, introduced the `rpc.admin-state` flag for the op-node, enabling high availability scenarios. Initially, it only existed on a separate branch. We have now merged it into the develop branch.

### Example

Add `--rpc.admin-state=/server/admin-state.log` parameter for op-node to enable this feature.


### Changes

Notable changes:
* Add `rpc.admin-state` flag for op-node.
