### PR TITLE
feat: add opbnb mainnet Fermat fork height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## v0.2.2
+
+This is the Fermat Hardfork release for opBNB Mainnet.
+It will be activated at block height 9397477, expected to occur on November 28, 2023, at 6 AM UTC.
+
+All mainnet nodes must upgrade to this release before the hardfork.
+
+### User Facing Changes
+
+- Support reading private keys from AWS Secret Manager for `op-node`, `op-batcher`, and `op-proposer`. Refer to PR #74 for additional information.
+
+### Partial Changelog
+
+- #72: feat: support AWS key manager
+
+### Docker Images
+
+- ghcr.io/bnb-chain/op-node:v0.2.2
+- ghcr.io/bnb-chain/op-batcher:v0.2.2
+- ghcr.io/bnb-chain/op-proposer:v0.2.2
+
+### Full Changelog
+
+https://github.com/bnb-chain/opbnb/compare/v0.2.1...v0.2.2
+
 ## v0.2.1
 
 This is a minor release and upgrading is optional.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All mainnet nodes must upgrade to this release before the hardfork.
 
 ### User Facing Changes
 
-- Support reading private keys from AWS Secret Manager for `op-node`, `op-batcher`, and `op-proposer`. Refer to PR #74 for additional information.
+- Support reading private keys from AWS Secret Manager for `op-node`, `op-batcher`, and `op-proposer`. Refer to PR #72 for additional information.
 
 ### Partial Changelog
 

--- a/op-node/chaincfg/chains.go
+++ b/op-node/chaincfg/chains.go
@@ -98,8 +98,7 @@ var OPBNBMainnet = rollup.Config{
 	DepositContractAddress: common.HexToAddress("0x1876ea7702c0ad0c6a2ae6036de7733edfbca519"),
 	L1SystemConfigAddress:  common.HexToAddress("0x7ac836148c14c74086d57f7828f2d065672db3b8"),
 	RegolithTime:           u64Ptr(0),
-	// TODO update block number
-	Fermat: nil,
+	Fermat:                 big.NewInt(9397477), // Nov-28-2023 06 AM +UTC
 }
 
 var OPBNBTestnet = rollup.Config{


### PR DESCRIPTION
### Description

Add opBNB mainnet Fermat fork height.

### Rationale

NA

### Example

NA

### Changes

Notable changes:
* change opBNB mainnet Fermat fork height
* add v0.2.2 changelog
