### PR TITLE
fix(op-node): change fallback client threshold to 10 from 20

### DIFF
--- a/op-node/sources/fallback_client.go
+++ b/op-node/sources/fallback_client.go
@@ -42,7 +42,7 @@ type FallbackClient struct {
 	metrics           metrics.Metricer
 }
 
-const threshold int64 = 20
+const threshold int64 = 10
 
 // NewFallbackClient returns a new FallbackClient. l1ChainId and l1Block are used to check
 // whether the newly switched rpc is legal.


### PR DESCRIPTION
### Description

I changed the threshold for fallbackClient to 10, previously 20 was too high.

### Rationale

We found that the threshold of 20 errors per minute is too high for nodes that are not sequencers, causing the fallbackClient to not function properly.

### Example

none

### Changes

Notable changes:
* threshold 20->10