### PR TITLE
feat(op-node): add opBNB bootnodes

### DIFF
--- a/op-node/p2p/cli/load_config.go
+++ b/op-node/p2p/cli/load_config.go
@@ -43,7 +43,7 @@ func NewConfig(ctx *cli.Context, rollupCfg *rollup.Config) (*p2p.Config, error) 
 		return nil, fmt.Errorf("failed to load p2p listen options: %w", err)
 	}
 
-	if err := loadDiscoveryOpts(conf, ctx); err != nil {
+	if err := loadDiscoveryOpts(conf, ctx, rollupCfg); err != nil {
 		return nil, fmt.Errorf("failed to load p2p discovery options: %w", err)
 	}
 
@@ -130,7 +130,7 @@ func loadListenOpts(conf *p2p.Config, ctx *cli.Context) error {
 	return nil
 }
 
-func loadDiscoveryOpts(conf *p2p.Config, ctx *cli.Context) error {
+func loadDiscoveryOpts(conf *p2p.Config, ctx *cli.Context, rollupCfg *rollup.Config) error {
 	if ctx.GlobalBool(flags.NoDiscovery.Name) {
 		conf.NoDiscovery = true
 	}
@@ -173,8 +173,14 @@ func loadDiscoveryOpts(conf *p2p.Config, ctx *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to open discovery db: %w", err)
 	}
-
-	records := strings.Split(ctx.GlobalString(flags.Bootnodes.Name), ",")
+	records := p2p.OpBNBMainnetBootnodes
+	if !ctx.IsSet(flags.Bootnodes.Name) {
+		if rollupCfg.L2ChainID.Cmp(p2p.OpBNBTestnet) == 0 {
+			records = p2p.OpBNBTestnetBootnodes
+		}
+	} else {
+		records = strings.Split(ctx.GlobalString(flags.Bootnodes.Name), ",")
+	}
 	for i, recordB64 := range records {
 		recordB64 = strings.TrimSpace(recordB64)
 		if recordB64 == "" { // ignore empty records

--- a/op-node/p2p/cli/load_config.go
+++ b/op-node/p2p/cli/load_config.go
@@ -178,14 +178,7 @@ func loadDiscoveryOpts(conf *p2p.Config, ctx *cli.Context, rollupCfg *rollup.Con
 		if rollupCfg.L2ChainID.Cmp(p2p.OpBNBTestnet) == 0 {
 			records = p2p.OpBNBTestnetBootnodes
 		} else {
-		    records = p2p.OpBNBMainnetBootnodes
-		}
-	} else {
-		records = strings.Split(ctx.GlobalString(flags.Bootnodes.Name), ",")
-	}
-	if !ctx.IsSet(flags.Bootnodes.Name) {
-		if rollupCfg.L2ChainID.Cmp(p2p.OpBNBTestnet) == 0 {
-			records = p2p.OpBNBTestnetBootnodes
+			records = p2p.OpBNBMainnetBootnodes
 		}
 	} else {
 		records = strings.Split(ctx.GlobalString(flags.Bootnodes.Name), ",")

--- a/op-node/p2p/cli/load_config.go
+++ b/op-node/p2p/cli/load_config.go
@@ -173,7 +173,16 @@ func loadDiscoveryOpts(conf *p2p.Config, ctx *cli.Context, rollupCfg *rollup.Con
 	if err != nil {
 		return fmt.Errorf("failed to open discovery db: %w", err)
 	}
-	records := p2p.OpBNBMainnetBootnodes
+	var records []string
+	if !ctx.IsSet(flags.Bootnodes.Name) {
+		if rollupCfg.L2ChainID.Cmp(p2p.OpBNBTestnet) == 0 {
+			records = p2p.OpBNBTestnetBootnodes
+		} else {
+		    records = p2p.OpBNBMainnetBootnodes
+		}
+	} else {
+		records = strings.Split(ctx.GlobalString(flags.Bootnodes.Name), ",")
+	}
 	if !ctx.IsSet(flags.Bootnodes.Name) {
 		if rollupCfg.L2ChainID.Cmp(p2p.OpBNBTestnet) == 0 {
 			records = p2p.OpBNBTestnetBootnodes

--- a/op-node/p2p/config.go
+++ b/op-node/p2p/config.go
@@ -37,7 +37,8 @@ var OpBNBTestnet = big.NewInt(5611)
 // the opBNB main network.
 var OpBNBMainnetBootnodes = []string{
 	// op-node
-	"enr:-J24QA9sgVxbZ0KoJ7-1gx_szfc7Oexzz7xL2iHS7VMHGj2QQaLc_IQZmFthywENgJWXbApj7tw7BiouKDOZD4noWEWGAYppffmvgmlkgnY0gmlwhDbjSM6Hb3BzdGFja4PMAQCJc2VjcDI1NmsxoQKetGQX7sXd4u8hZr6uayTZgHRDvGm36YaryqZkgnidS4N0Y3CCIyuDdWRwgiMs",
+	"enr:-J24QIGeBCpZHdaQ5i8fyyK_uzaL1DdgOOZA3_lvjHvirjpgexMGkVeGMxlqauzEX7pWAfztCa9hpEGd_bS2a-1IqB6GAYvRDk5QgmlkgnY0gmlwhDaykUmHb3BzdGFja4PMAQCJc2VjcDI1NmsxoQJ-_5GZKjs7jaB4TILdgC8EwnwyL3Qip89wmjnyjvDDwoN0Y3CCIyuDdWRwgiMs",
+	"enr:-J24QO_AhXy6stHsVvFWnECRD_1hMccZM6JqJgiXNVIRED1JRAJvIS48Pihku2z30TfizSGUAmeb22RQfPjW99hDu9WGAYvRBDnegmlkgnY0gmlwhDbjSM6Hb3BzdGFja4PMAQCJc2VjcDI1NmsxoQKetGQX7sXd4u8hZr6uayTZgHRDvGm36YaryqZkgnidS4N0Y3CCIyuDdWRwgiMs",
 }
 
 // OpBNBTestnetBootnodes are the enode URLs of the P2P bootstrap nodes running on

--- a/op-node/p2p/config.go
+++ b/op-node/p2p/config.go
@@ -31,10 +31,7 @@ var DefaultBootnodes = []*enode.Node{
 	enode.MustParse("enode://9d7a3efefe442351217e73b3a593bcb8efffb55b4807699972145324eab5e6b382152f8d24f6301baebbfb5ecd4127bd3faab2842c04cd432bdf50ba092f6645@34.65.109.126:0?discport=30305"),
 }
 
-var (
-	OpBNBMainnet = big.NewInt(204)
-	OpBNBTestnet = big.NewInt(5611)
-)
+var OpBNBTestnet = big.NewInt(5611)
 
 // OpBNBMainnetBootnodes are the enode URLs of the P2P bootstrap nodes running on
 // the opBNB main network.

--- a/op-node/p2p/config.go
+++ b/op-node/p2p/config.go
@@ -3,6 +3,7 @@ package p2p
 import (
 	"errors"
 	"fmt"
+	"math/big"
 	"net"
 	"time"
 
@@ -28,6 +29,26 @@ var DefaultBootnodes = []*enode.Node{
 	enode.MustParse("enode://869d07b5932f17e8490990f75a3f94195e9504ddb6b85f7189e5a9c0a8fff8b00aecf6f3ac450ecba6cdabdb5858788a94bde2b613e0f2d82e9b395355f76d1a@34.65.67.101:0?discport=30305"),
 	enode.MustParse("enode://2d4e7e9d48f4dd4efe9342706dd1b0024681bd4c3300d021f86fc75eab7865d4e0cbec6fbc883f011cfd6a57423e7e2f6e104baad2b744c3cafaec6bc7dc92c1@34.65.43.171:0?discport=30305"),
 	enode.MustParse("enode://9d7a3efefe442351217e73b3a593bcb8efffb55b4807699972145324eab5e6b382152f8d24f6301baebbfb5ecd4127bd3faab2842c04cd432bdf50ba092f6645@34.65.109.126:0?discport=30305"),
+}
+
+var (
+	OpBNBMainnet = big.NewInt(204)
+	OpBNBTestnet = big.NewInt(5611)
+)
+
+// OpBNBMainnetBootnodes are the enode URLs of the P2P bootstrap nodes running on
+// the opBNB main network.
+var OpBNBMainnetBootnodes = []string{
+	// op-node
+	"enr:-J24QA9sgVxbZ0KoJ7-1gx_szfc7Oexzz7xL2iHS7VMHGj2QQaLc_IQZmFthywENgJWXbApj7tw7BiouKDOZD4noWEWGAYppffmvgmlkgnY0gmlwhDbjSM6Hb3BzdGFja4PMAQCJc2VjcDI1NmsxoQKetGQX7sXd4u8hZr6uayTZgHRDvGm36YaryqZkgnidS4N0Y3CCIyuDdWRwgiMs",
+}
+
+// OpBNBTestnetBootnodes are the enode URLs of the P2P bootstrap nodes running on
+// the opBNB testnet network.
+var OpBNBTestnetBootnodes = []string{
+	// op-node
+	"enr:-J24QGQBeMsXOaCCaLWtNFSfb2Gv50DjGOKToH2HUTAIn9yXImowlRoMDNuPNhSBZNQGCCE8eAl5O3dsONuuQp5Qix2GAYjB7KHSgmlkgnY0gmlwhDREiqaHb3BzdGFja4PrKwCJc2VjcDI1NmsxoQL4I9wpEVDcUb8bLWu6V8iPoN5w8E8q-GrS5WUCygYUQ4N0Y3CCIyuDdWRwgiMr",
+	"enr:-J24QJKXHEkIhy0tmIk2EscMZ2aRrivNsZf_YhgIU51g4ZKHWY0BxW6VedRJ1jxmneW9v7JjldPOPpLkaNSo6cXGFxqGAYpK96oCgmlkgnY0gmlwhANzx96Hb3BzdGFja4PrKwCJc2VjcDI1NmsxoQMOCzUFffz04eyDrmkbaSCrMEvLvn5O4RZaZ5k1GV4wa4N0Y3CCIyuDdWRwgiMr",
 }
 
 type HostMetrics interface {


### PR DESCRIPTION
### Description

Add `opBNB` testnet and mainnet bootnodes in code.

### Rationale

Add `opBNB` testnet and mainnet bootnodes in code can facilitate the startup of new nodes.

### Example

The startup node will use the `opBNB` bootnodes by chainId including testnet and mainnet. If `p2p.bootnodes` is configured, the configured bootnodes will be used. The configured `p2p.bootnodes` have the highest priority.

### Changes

Add `opBNB` testnet and mainnet bootnodes in code.
