### PR TITLE
fix(ci): fix labeler fail

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,4 @@
 ---
 C-Protocol-Critical:
-  - 'packages/contracts-bedrock/**/*.sol'
+  - changed-files:
+    - any-glob-to-any-file: 'packages/contracts-bedrock/**/*.sol'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -7,7 +7,7 @@ jobs:
   pr-labeler:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@main
+      - uses: actions/labeler@v5.0.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: .github/labeler.yml


### PR DESCRIPTION
### Description

Due to the latest 5.0 version of the labeler component making incompatible changes to the configuration file format, our labeler ci workflow is not functioning properly. I have made fixes for this.

### Rationale

The latest version of the labeler component has made incompatible changes to the configuration file format, see: https://github.com/actions/labeler/releases/tag/v5.0.0

### Example

none

### Changes

Notable changes:
* Modify labeler.yml configuration file
