### PR TITLE
feature(op-node): pre-fetch receipts concurrently

### DIFF
--- a/op-node/rollup/derive/engine_queue.go
+++ b/op-node/rollup/derive/engine_queue.go
@@ -787,7 +787,7 @@ func (eq *EngineQueue) Reset(ctx context.Context, _ eth.L1BlockRef, _ eth.System
 	if err != nil {
 		return NewTemporaryError(fmt.Errorf("failed to fetch L1 config of L2 block %s: %w", pipelineL2.ID(), err))
 	}
-	err2 := eq.l1Fetcher.GoOrUpdatePreFetchReceipts(ctx, pipelineOrigin.Number)
+	err2 := eq.l1Fetcher.GoOrUpdatePreFetchReceipts(context.Background(), pipelineOrigin.Number)
 	if err2 != nil {
 		return NewTemporaryError(fmt.Errorf("failed to run pre fetch L1 receipts for L1 start block %s: %w", pipelineOrigin.ID(), err2))
 	}

--- a/op-node/sources/l1_client.go
+++ b/op-node/sources/l1_client.go
@@ -39,7 +39,7 @@ func L1ClientDefaultConfig(config *rollup.Config, trustRPC bool, kind RPCProvide
 			HeadersCacheSize:      span,
 			PayloadsCacheSize:     span,
 			MaxRequestsPerBatch:   20, // TODO: tune batch param
-			MaxConcurrentRequests: 10,
+			MaxConcurrentRequests: 20,
 			TrustRPC:              trustRPC,
 			MustBePostMerge:       false,
 			RPCProviderKind:       kind,
@@ -82,7 +82,7 @@ func NewL1Client(client client.RPC, log log.Logger, metrics caching.Metrics, con
 		l1BlockRefsCache:               caching.NewLRUCache(metrics, "blockrefs", config.L1BlockRefsCacheSize),
 		preFetchReceiptsOnce:           sync.Once{},
 		preFetchReceiptsStartBlockChan: make(chan uint64, 1),
-		preFetchReceiptsRateLimiter:    rate.NewLimiter(rate.Limit(config.MaxConcurrentRequests), config.MaxConcurrentRequests),
+		preFetchReceiptsRateLimiter:    rate.NewLimiter(rate.Limit(config.MaxConcurrentRequests/2), config.MaxConcurrentRequests/2),
 		done:                           make(chan struct{}),
 	}, nil
 }


### PR DESCRIPTION
### Description
I added pre-fetch receipt logic in the https://github.com/bnb-chain/opbnb/pull/57. However, if the L1 endpoint is not functioning well and the interface response time increases, the efficiency of pre-fetch will be significantly reduced. To address this issue, we parallelize the pre-fetch process for multiple future block heights. This allows us to achieve better performance even when the L1 endpoint is not in good condition.


### Rationale

To solve the problem of low L1 endpoint performance, we have added concurrent logic to improve the efficiency of pre-fetching receipts.

### Example

none

### Changes

Notable changes:
* Pre-fetch adds concurrency logic.
* The context passed into GoOrUpdatePreFetchReceipts has been modified to use the background context, as the ctx has a timeout of 3 seconds. We do not currently need a timeout here.
