### PR TITLE
optimize(op-node): continue optimizing sequencer step schedule

### DIFF
--- a/op-node/rollup/driver/sequencer.go
+++ b/op-node/rollup/driver/sequencer.go
@@ -45,6 +45,9 @@ type Sequencer struct {
 	timeNow func() time.Time
 
 	nextAction time.Time
+
+	// if accEmptyBlocks>10, will delay nextAction 600ms for full block building
+	accEmptyBlocks int
 }
 
 func NewSequencer(log log.Logger, cfg *rollup.Config, engine derive.ResettableEngineControl, attributesBuilder derive.AttributesBuilder, l1OriginSelector L1OriginSelectorIface, metrics SequencerMetrics) *Sequencer {
@@ -227,6 +230,9 @@ func (d *Sequencer) RunNextSequencerAction(ctx context.Context) (*eth.ExecutionP
 			return nil, nil
 		} else {
 			d.attrBuilder.CachePayloadByHash(payload)
+			if len(payload.Transactions) == 1 {
+				d.accEmptyBlocks += 1
+			}
 			d.log.Info("sequencer successfully built a new block", "block", payload.ID(), "time", uint64(payload.Timestamp), "txs", len(payload.Transactions))
 			return payload, nil
 		}
@@ -249,6 +255,11 @@ func (d *Sequencer) RunNextSequencerAction(ctx context.Context) (*eth.ExecutionP
 			}
 		} else {
 			parent, buildingID, _ := d.engine.BuildingPayload() // we should have a new payload ID now that we're building a block
+			if d.accEmptyBlocks > 10 {
+				d.nextAction = d.timeNow().Add(600 * time.Millisecond)
+				d.accEmptyBlocks = 0
+				d.log.Info("sequencer delay next action 600ms and reset accEmptyBlocks")
+			}
 			d.log.Info("sequencer started building new block", "payload_id", buildingID, "l2_parent_block", parent, "l2_parent_block_time", parent.Time)
 		}
 		return nil, nil


### PR DESCRIPTION
### Description
continue optimizing sequencer step schedule 
### Rationale
there're still some corner cases, in which sequencer block produce may has issue:
1. if whole l1 network went down for more than maxSequencerDrift time, sequencer was unable to auto-recover after l1 network recovered
2. when high l1 network latency last for a long time(> maxSequencerDrift), sequencer will produce block but difficult to produce full block
3. when sequencer step is hot(e.g. catching up),  admin_stopSequencer operation may failed due to context timeout

this PR will fix above cases.
### Example
n/a
### Changes
1. call sequencerStep() immediately rather than reset sequencerTimer
2. handle l1HeadSig before call sequencerStep() to avoid error caused by cannot find next l1 block
3. add accEmptyBlocks in sequencer.go to avoid never produce full block in corner case
4. add more steps to high priority schedule

