### PR TITLE
receipt cache limited by volumes

### DIFF
--- a/op-node/sources/caching/blob_lru.go
+++ b/op-node/sources/caching/blob_lru.go
@@ -7,7 +7,7 @@ import (
 	lru "github.com/hashicorp/golang-lru/v2"
 )
 
-type SizeFn func(value any) int
+type SizeFn func(value any) uint64
 
 // SizeConstrainedCache is a cache where capacity is in bytes (instead of item count). When the cache
 // is at capacity, and a new item is added, older items are evicted until the size
@@ -18,15 +18,15 @@ type SizeFn func(value any) int
 type SizeConstrainedCache[K comparable, V any] struct {
 	m       Metrics
 	label   string
-	size    int
-	maxSize int
+	size    uint64
+	maxSize uint64
 	sizeFn  SizeFn
 	lru     *lru.Cache[K, V]
 	lock    sync.Mutex
 }
 
 // NewSizeConstrainedCache creates a new size-constrained LRU cache.
-func NewSizeConstrainedCache[K comparable, V any](m Metrics, label string, maxSize int, sizeFn SizeFn) *SizeConstrainedCache[K, V] {
+func NewSizeConstrainedCache[K comparable, V any](m Metrics, label string, maxSize uint64, sizeFn SizeFn) *SizeConstrainedCache[K, V] {
 	cache, _ := lru.New[K, V](math.MaxInt)
 	return &SizeConstrainedCache[K, V]{
 		m:       m,

--- a/op-node/sources/caching/blob_lru.go
+++ b/op-node/sources/caching/blob_lru.go
@@ -1,0 +1,82 @@
+package caching
+
+import (
+	lru "github.com/hashicorp/golang-lru/v2"
+	"math"
+	"sync"
+)
+
+type SizeFn func(value any) int
+
+// SizeConstrainedCache is a cache where capacity is in bytes (instead of item count). When the cache
+// is at capacity, and a new item is added, older items are evicted until the size
+// constraint is met.
+//
+// OBS: This cache assumes that items are content-addressed: keys are unique per content.
+// In other words: two Add(..) with the same key K, will always have the same value V.
+type SizeConstrainedCache[K comparable, V any] struct {
+	m       Metrics
+	label   string
+	size    int
+	maxSize int
+	sizeFn  SizeFn
+	lru     *lru.Cache[K, V]
+	lock    sync.Mutex
+}
+
+// NewSizeConstrainedCache creates a new size-constrained LRU cache.
+func NewSizeConstrainedCache[K comparable, V any](m Metrics, label string, maxSize int, sizeFn SizeFn) *SizeConstrainedCache[K, V] {
+	cache, _ := lru.New[K, V](math.MaxInt)
+	return &SizeConstrainedCache[K, V]{
+		m:       m,
+		label:   label,
+		size:    0,
+		maxSize: maxSize,
+		sizeFn:  sizeFn,
+		lru:     cache,
+	}
+}
+
+// Add adds a value to the cache.  Returns true if an eviction occurred.
+// OBS: This cache assumes that items are content-addressed: keys are unique per content.
+// In other words: two Add(..) with the same key K, will always have the same value V.
+// OBS: The value is _not_ copied on Add, so the caller must not modify it afterwards.
+func (c *SizeConstrainedCache[K, V]) Add(key K, value V) (evicted bool) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	// Unless it is already present, might need to evict something.
+	// OBS: If it is present, we still call Add internally to bump the recentness.
+	if !c.lru.Contains(key) {
+		targetSize := c.size + c.sizeFn(value)
+		for targetSize > c.maxSize {
+			evicted = true
+			_, v, ok := c.lru.RemoveOldest()
+			if !ok {
+				// list is now empty. Break
+				break
+			}
+			targetSize -= c.sizeFn(v)
+		}
+		c.size = targetSize
+	}
+
+	c.lru.Add(key, value)
+	if c.m != nil {
+		c.m.CacheAdd(c.label, c.lru.Len(), evicted)
+	}
+
+	return evicted
+}
+
+// Get looks up a key's value from the cache.
+func (c *SizeConstrainedCache[K, V]) Get(key K) (V, bool) {
+	c.lock.Lock()
+	value, ok := c.lru.Get(key)
+	c.lock.Unlock()
+
+	if c.m != nil {
+		c.m.CacheGet(c.label, ok)
+	}
+	return value, ok
+}

--- a/op-node/sources/eth_client.go
+++ b/op-node/sources/eth_client.go
@@ -384,10 +384,6 @@ func (s *EthClient) FetchReceipts(ctx context.Context, blockHash common.Hash) (e
 	} else {
 		txHashes := eth.TransactionsToHashes(txs)
 		job = NewReceiptsFetchingJob(s, s.client, s.maxBatchSize, eth.ToBlockID(info), info.ReceiptHash(), txHashes)
-		_, err := job.Fetch(ctx)
-		if err != nil {
-			return nil, nil, err
-		}
 		s.receiptsCache.Add(blockHash, job)
 	}
 
@@ -395,6 +391,8 @@ func (s *EthClient) FetchReceipts(ctx context.Context, blockHash common.Hash) (e
 	if err != nil {
 		return nil, nil, err
 	}
+
+	s.receiptsCache.Add(blockHash, job)
 
 	return info, receipts, nil
 }

--- a/op-node/sources/eth_client.go
+++ b/op-node/sources/eth_client.go
@@ -36,9 +36,9 @@ type EthClientConfig struct {
 	// cache sizes
 
 	// Volume of blocks worth of receipts to cache
-	ReceiptsCacheVolumeByte int
+	ReceiptsCacheVolumeByte uint64
 	// Volume of blocks worth of transactions to cache
-	TransactionsCacheVolumeByte int
+	TransactionsCacheVolumeByte uint64
 	// Number of block headers to cache
 	HeadersCacheSize int
 	// Number of payloads to cache
@@ -65,12 +65,6 @@ type EthClientConfig struct {
 }
 
 func (c *EthClientConfig) Check() error {
-	if c.ReceiptsCacheVolumeByte < 0 {
-		return fmt.Errorf("invalid receipts cache volume: %d", c.ReceiptsCacheVolumeByte)
-	}
-	if c.TransactionsCacheVolumeByte < 0 {
-		return fmt.Errorf("invalid transactions cache volume: %d", c.TransactionsCacheVolumeByte)
-	}
 	if c.HeadersCacheSize < 0 {
 		return fmt.Errorf("invalid headers cache size: %d", c.HeadersCacheSize)
 	}
@@ -165,17 +159,17 @@ func NewEthClient(client client.RPC, log log.Logger, metrics caching.Metrics, co
 		return nil, fmt.Errorf("bad config, cannot create L1 source: %w", err)
 	}
 	client = LimitRPC(client, config.MaxConcurrentRequests)
-	receiptsFetchingJobSizeFn := func(value any) (size int) {
+	receiptsFetchingJobSizeFn := func(value any) (size uint64) {
 		job := value.(*receiptsFetchingJob)
 		for _, rec := range job.result {
-			size += int(rec.Size())
+			size += uint64(rec.Size())
 		}
 		return
 	}
-	transactionsSizeFn := func(value any) (size int) {
+	transactionsSizeFn := func(value any) (size uint64) {
 		transactions := value.(types.Transactions)
 		for _, tx := range transactions {
-			size += int(tx.Size())
+			size += tx.Size()
 		}
 		return
 	}

--- a/op-node/sources/eth_client_test.go
+++ b/op-node/sources/eth_client_test.go
@@ -44,15 +44,15 @@ func (m *mockRPC) Close() {
 var _ client.RPC = (*mockRPC)(nil)
 
 var testEthClientConfig = &EthClientConfig{
-	ReceiptsCacheSize:     10,
-	TransactionsCacheSize: 10,
-	HeadersCacheSize:      10,
-	PayloadsCacheSize:     10,
-	MaxRequestsPerBatch:   20,
-	MaxConcurrentRequests: 10,
-	TrustRPC:              false,
-	MustBePostMerge:       false,
-	RPCProviderKind:       RPCKindBasic,
+	ReceiptsCacheVolumeByte:     10 * 1024 * 1024,
+	TransactionsCacheVolumeByte: 10 * 1024 * 1024,
+	HeadersCacheSize:            10,
+	PayloadsCacheSize:           10,
+	MaxRequestsPerBatch:         20,
+	MaxConcurrentRequests:       10,
+	TrustRPC:                    false,
+	MustBePostMerge:             false,
+	RPCProviderKind:             RPCKindBasic,
 }
 
 func randHash() (out common.Hash) {

--- a/op-node/sources/l1_client.go
+++ b/op-node/sources/l1_client.go
@@ -34,8 +34,8 @@ func L1ClientDefaultConfig(config *rollup.Config, trustRPC bool, kind RPCProvide
 	return &L1ClientConfig{
 		EthClientConfig: EthClientConfig{
 			// receipts and transactions are cached per block
-			ReceiptsCacheVolumeByte:     span * 1024 * 1024,
-			TransactionsCacheVolumeByte: span * 1024 * 1024,
+			ReceiptsCacheVolumeByte:     uint64(span * 1024 * 1024),
+			TransactionsCacheVolumeByte: uint64(span * 1024 * 1024),
 			HeadersCacheSize:            span,
 			PayloadsCacheSize:           span,
 			MaxRequestsPerBatch:         20, // TODO: tune batch param

--- a/op-node/sources/l1_client.go
+++ b/op-node/sources/l1_client.go
@@ -34,16 +34,16 @@ func L1ClientDefaultConfig(config *rollup.Config, trustRPC bool, kind RPCProvide
 	return &L1ClientConfig{
 		EthClientConfig: EthClientConfig{
 			// receipts and transactions are cached per block
-			ReceiptsCacheSize:     span,
-			TransactionsCacheSize: span,
-			HeadersCacheSize:      span,
-			PayloadsCacheSize:     span,
-			MaxRequestsPerBatch:   20, // TODO: tune batch param
-			MaxConcurrentRequests: 20,
-			TrustRPC:              trustRPC,
-			MustBePostMerge:       false,
-			RPCProviderKind:       kind,
-			MethodResetDuration:   time.Minute,
+			ReceiptsCacheVolumeByte:     span * 1024 * 1024,
+			TransactionsCacheVolumeByte: span * 1024 * 1024,
+			HeadersCacheSize:            span,
+			PayloadsCacheSize:           span,
+			MaxRequestsPerBatch:         20, // TODO: tune batch param
+			MaxConcurrentRequests:       20,
+			TrustRPC:                    trustRPC,
+			MustBePostMerge:             false,
+			RPCProviderKind:             kind,
+			MethodResetDuration:         time.Minute,
 		},
 		// Not bounded by span, to cover find-sync-start range fully for speedy recovery after errors.
 		L1BlockRefsCacheSize: fullSpan,

--- a/op-node/sources/l2_client.go
+++ b/op-node/sources/l2_client.go
@@ -42,8 +42,8 @@ func L2ClientDefaultConfig(config *rollup.Config, trustRPC bool) *L2ClientConfig
 	return &L2ClientConfig{
 		EthClientConfig: EthClientConfig{
 			// receipts and transactions are cached per block
-			ReceiptsCacheVolumeByte:     span * 1024 * 1024,
-			TransactionsCacheVolumeByte: span * 1024 * 1024,
+			ReceiptsCacheVolumeByte:     uint64(span * 1024 * 1024),
+			TransactionsCacheVolumeByte: uint64(span * 1024 * 1024),
 			HeadersCacheSize:            span,
 			PayloadsCacheSize:           span,
 			MaxRequestsPerBatch:         20, // TODO: tune batch param

--- a/op-node/sources/l2_client.go
+++ b/op-node/sources/l2_client.go
@@ -42,16 +42,16 @@ func L2ClientDefaultConfig(config *rollup.Config, trustRPC bool) *L2ClientConfig
 	return &L2ClientConfig{
 		EthClientConfig: EthClientConfig{
 			// receipts and transactions are cached per block
-			ReceiptsCacheSize:     span,
-			TransactionsCacheSize: span,
-			HeadersCacheSize:      span,
-			PayloadsCacheSize:     span,
-			MaxRequestsPerBatch:   20, // TODO: tune batch param
-			MaxConcurrentRequests: 10,
-			TrustRPC:              trustRPC,
-			MustBePostMerge:       true,
-			RPCProviderKind:       RPCKindBasic,
-			MethodResetDuration:   time.Minute,
+			ReceiptsCacheVolumeByte:     span * 1024 * 1024,
+			TransactionsCacheVolumeByte: span * 1024 * 1024,
+			HeadersCacheSize:            span,
+			PayloadsCacheSize:           span,
+			MaxRequestsPerBatch:         20, // TODO: tune batch param
+			MaxConcurrentRequests:       10,
+			TrustRPC:                    trustRPC,
+			MustBePostMerge:             true,
+			RPCProviderKind:             RPCKindBasic,
+			MethodResetDuration:         time.Minute,
 		},
 		// Not bounded by span, to cover find-sync-start range fully for speedy recovery after errors.
 		L2BlockRefsCacheSize: fullSpan,

--- a/op-node/sources/receipts_test.go
+++ b/op-node/sources/receipts_test.go
@@ -147,16 +147,16 @@ func (tc *ReceiptsTestCase) Run(t *testing.T) {
 	cl := rpc.DialInProc(srv)
 	testCfg := &EthClientConfig{
 		// receipts and transactions are cached per block
-		ReceiptsCacheSize:     1000,
-		TransactionsCacheSize: 1000,
-		HeadersCacheSize:      1000,
-		PayloadsCacheSize:     1000,
-		MaxRequestsPerBatch:   20,
-		MaxConcurrentRequests: 10,
-		TrustRPC:              false,
-		MustBePostMerge:       false,
-		RPCProviderKind:       tc.providerKind,
-		MethodResetDuration:   time.Minute,
+		ReceiptsCacheVolumeByte:     1000 * 1024 * 1024,
+		TransactionsCacheVolumeByte: 1000 * 1024 * 1024,
+		HeadersCacheSize:            1000,
+		PayloadsCacheSize:           1000,
+		MaxRequestsPerBatch:         20,
+		MaxConcurrentRequests:       10,
+		TrustRPC:                    false,
+		MustBePostMerge:             false,
+		RPCProviderKind:             tc.providerKind,
+		MethodResetDuration:         time.Minute,
 	}
 	if tc.staticMethod { // if static, instantly reset, for fast clock-independent testing
 		testCfg.MethodResetDuration = 0


### PR DESCRIPTION
The receipts cache was originally a LRUCache type that was limited by the number of elements, but there is a problem, meaning that if the recent block contains too many receipts, then the receipts cache can take up a lot of memory. To limit the memory usage of the receipts cache, this PR changes the cache type to SizeConstrainedCache, which is limited by the total volume of elements.