### PR TITLE
feat(op-node): pre-fetch receipts concurrently round 2

### DIFF
--- a/op-node/rollup/derive/attributes.go
+++ b/op-node/rollup/derive/attributes.go
@@ -20,6 +20,7 @@ type L1ReceiptsFetcher interface {
 	InfoByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, error)
 	InfoAndTxsByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, types.Transactions, error)
 	FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error)
+	PreFetchReceipts(ctx context.Context, blockHash common.Hash) (bool, error)
 	GoOrUpdatePreFetchReceipts(ctx context.Context, l1StartBlock uint64) error
 }
 

--- a/op-node/rollup/derive/attributes.go
+++ b/op-node/rollup/derive/attributes.go
@@ -22,6 +22,7 @@ type L1ReceiptsFetcher interface {
 	FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error)
 	PreFetchReceipts(ctx context.Context, blockHash common.Hash) (bool, error)
 	GoOrUpdatePreFetchReceipts(ctx context.Context, l1StartBlock uint64) error
+	ClearReceiptsCacheBefore(blockNumber uint64)
 }
 
 type SystemConfigL2Fetcher interface {

--- a/op-node/rollup/derive/engine_queue.go
+++ b/op-node/rollup/derive/engine_queue.go
@@ -402,6 +402,7 @@ func (eq *EngineQueue) postProcessSafeL2() {
 			eq.log.Debug("updated finality-data", "last_l1", last.L1Block, "last_l2", last.L2Block)
 		}
 	}
+	eq.l1Fetcher.ClearReceiptsCacheBefore(eq.safeHead.L1Origin.Number)
 }
 
 func (eq *EngineQueue) logSyncProgress(reason string) {

--- a/op-node/rollup/derive/engine_queue_test.go
+++ b/op-node/rollup/derive/engine_queue_test.go
@@ -951,6 +951,7 @@ func TestBlockBuildingRace(t *testing.T) {
 
 	// Expect initial forkchoice update
 	eng.ExpectForkchoiceUpdate(preFc, nil, preFcRes, nil)
+	l1F.ExpectClearReceiptsCacheBefore(refA.Number)
 	require.NoError(t, eq.Step(context.Background()), "clean forkchoice state after reset")
 
 	// Expect initial building update, to process the attributes we queued up
@@ -1018,6 +1019,7 @@ func TestBlockBuildingRace(t *testing.T) {
 	}
 	eng.ExpectForkchoiceUpdate(postFc, nil, postFcRes, nil)
 
+	l1F.ExpectClearReceiptsCacheBefore(refA.Number)
 	// Now complete the job, as external user of the engine
 	_, _, err = eq.ConfirmPayload(context.Background())
 	require.NoError(t, err)
@@ -1106,6 +1108,7 @@ func TestResetLoop(t *testing.T) {
 	eq.engineSyncTarget = refA2
 	eq.safeHead = refA1
 	eq.finalized = refA0
+	l1F.ExpectClearReceiptsCacheBefore(refA.Number)
 
 	// Qeueue up the safe attributes
 	require.Nil(t, eq.safeAttributes)
@@ -1124,6 +1127,7 @@ func TestResetLoop(t *testing.T) {
 	eng.ExpectForkchoiceUpdate(preFc, nil, nil, nil)
 	require.NoError(t, eq.Step(context.Background()), "clean forkchoice state after reset")
 
+	l1F.ExpectClearReceiptsCacheBefore(refA.Number)
 	// Crux of the test. Should be in a valid state after the reset.
 	require.ErrorIs(t, eq.Step(context.Background()), NotEnoughData, "Should be able to step after a reset")
 

--- a/op-node/rollup/derive/engine_queue_test.go
+++ b/op-node/rollup/derive/engine_queue_test.go
@@ -260,12 +260,14 @@ func TestEngineQueue_Finalize(t *testing.T) {
 	eq.origin = refD
 	prev.origin = refD
 	eq.safeHead = refC1
+	l1F.ExpectClearReceiptsCacheBefore(refC1.L1Origin.Number)
 	eq.postProcessSafeL2()
 
 	// now say D0 was included in E and became the new safe head
 	eq.origin = refE
 	prev.origin = refE
 	eq.safeHead = refD0
+	l1F.ExpectClearReceiptsCacheBefore(refD0.L1Origin.Number)
 	eq.postProcessSafeL2()
 
 	// let's finalize D (current L1), from which we fully derived C1 (it was safe head), but not D0 (included in E)

--- a/op-node/rollup/derive/l1_traversal.go
+++ b/op-node/rollup/derive/l1_traversal.go
@@ -20,6 +20,7 @@ import (
 type L1BlockRefByNumberFetcher interface {
 	L1BlockRefByNumber(context.Context, uint64) (eth.L1BlockRef, error)
 	FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error)
+	PreFetchReceipts(ctx context.Context, blockHash common.Hash) (bool, error)
 }
 
 type L1Traversal struct {

--- a/op-node/rollup/driver/metered_l1fetcher.go
+++ b/op-node/rollup/driver/metered_l1fetcher.go
@@ -76,3 +76,8 @@ func (m *MeteredL1Fetcher) GoOrUpdatePreFetchReceipts(ctx context.Context, l1Sta
 	defer m.recordTime("GoOrUpdatePreFetchReceipts")()
 	return m.inner.GoOrUpdatePreFetchReceipts(ctx, l1StartBlock)
 }
+
+func (m *MeteredL1Fetcher) ClearReceiptsCacheBefore(blockNumber uint64) {
+	defer m.recordTime("ClearReceiptsCacheBefore")()
+	m.inner.ClearReceiptsCacheBefore(blockNumber)
+}

--- a/op-node/rollup/driver/metered_l1fetcher.go
+++ b/op-node/rollup/driver/metered_l1fetcher.go
@@ -57,6 +57,11 @@ func (m *MeteredL1Fetcher) FetchReceipts(ctx context.Context, blockHash common.H
 	return m.inner.FetchReceipts(ctx, blockHash)
 }
 
+func (m *MeteredL1Fetcher) PreFetchReceipts(ctx context.Context, blockHash common.Hash) (bool, error) {
+	defer m.recordTime("PreFetchReceipts")()
+	return m.inner.PreFetchReceipts(ctx, blockHash)
+}
+
 var _ derive.L1Fetcher = (*MeteredL1Fetcher)(nil)
 
 func (m *MeteredL1Fetcher) recordTime(method string) func() {

--- a/op-node/rollup/driver/sequencer.go
+++ b/op-node/rollup/driver/sequencer.go
@@ -18,6 +18,7 @@ import (
 type Downloader interface {
 	InfoByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, error)
 	FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error)
+	PreFetchReceipts(ctx context.Context, blockHash common.Hash) (bool, error)
 }
 
 type L1OriginSelectorIface interface {

--- a/op-node/sources/caching/cache.go
+++ b/op-node/sources/caching/cache.go
@@ -1,8 +1,6 @@
 package caching
 
-import (
-	lru "github.com/hashicorp/golang-lru"
-)
+import lru "github.com/hashicorp/golang-lru"
 
 type Metrics interface {
 	CacheAdd(label string, cacheSize int, evicted bool)

--- a/op-node/sources/caching/cache.go
+++ b/op-node/sources/caching/cache.go
@@ -55,6 +55,7 @@ func (c *LRUCache) PeekAndCleanOld(key any) (value any, ok bool) {
 			oKey, _, oOk := c.inner.GetOldest()
 			if oOk && oKey != key {
 				c.inner.RemoveOldest()
+				continue
 			}
 			break
 		}

--- a/op-node/sources/caching/cache.go
+++ b/op-node/sources/caching/cache.go
@@ -28,11 +28,23 @@ func (c *LRUCache) Get(key any) (value any, ok bool) {
 	return value, ok
 }
 
+func (c *LRUCache) Add(key, value any) (evicted bool) {
+	evicted = c.inner.Add(key, value)
+	if c.m != nil {
+		c.m.CacheAdd(c.label, c.inner.Len(), evicted)
+	}
+	return evicted
+}
+
 func (c *LRUCache) Peek(key any) (value any, ok bool) {
+	defer c.lock.Unlock()
+	c.lock.Lock()
 	return c.inner.Peek(key)
 }
 
 func (c *LRUCache) PeekAndCleanOld(key any) (value any, ok bool) {
+	defer c.lock.Unlock()
+	c.lock.Lock()
 	value, ok = c.inner.Peek(key)
 	if c.m != nil {
 		c.m.CacheGet(c.label, ok)
@@ -48,14 +60,6 @@ func (c *LRUCache) PeekAndCleanOld(key any) (value any, ok bool) {
 		}
 	}
 	return value, ok
-}
-
-func (c *LRUCache) Add(key, value any) (evicted bool) {
-	evicted = c.inner.Add(key, value)
-	if c.m != nil {
-		c.m.CacheAdd(c.label, c.inner.Len(), evicted)
-	}
-	return evicted
 }
 
 func (c *LRUCache) AddIfNotFull(key, value any) (evicted bool, full bool) {

--- a/op-node/sources/caching/cache.go
+++ b/op-node/sources/caching/cache.go
@@ -1,6 +1,10 @@
 package caching
 
-import lru "github.com/hashicorp/golang-lru"
+import (
+	"sync"
+
+	lru "github.com/hashicorp/golang-lru"
+)
 
 type Metrics interface {
 	CacheAdd(label string, cacheSize int, evicted bool)
@@ -9,15 +13,39 @@ type Metrics interface {
 
 // LRUCache wraps hashicorp *lru.Cache and tracks cache metrics
 type LRUCache struct {
-	m     Metrics
-	label string
-	inner *lru.Cache
+	m       Metrics
+	label   string
+	inner   *lru.Cache
+	lock    sync.Mutex
+	maxSize int
 }
 
 func (c *LRUCache) Get(key any) (value any, ok bool) {
 	value, ok = c.inner.Get(key)
 	if c.m != nil {
 		c.m.CacheGet(c.label, ok)
+	}
+	return value, ok
+}
+
+func (c *LRUCache) Peek(key any) (value any, ok bool) {
+	return c.inner.Peek(key)
+}
+
+func (c *LRUCache) PeekAndCleanOld(key any) (value any, ok bool) {
+	value, ok = c.inner.Peek(key)
+	if c.m != nil {
+		c.m.CacheGet(c.label, ok)
+	}
+	if ok {
+		for {
+			//Remove all elements older than the current element, as when retrieving that element, all elements older than it should have expired.
+			oKey, _, oOk := c.inner.GetOldest()
+			if oOk && oKey != key {
+				c.inner.RemoveOldest()
+			}
+			break
+		}
 	}
 	return value, ok
 }
@@ -30,14 +58,28 @@ func (c *LRUCache) Add(key, value any) (evicted bool) {
 	return evicted
 }
 
+func (c *LRUCache) AddIfNotFull(key, value any) (evicted bool, full bool) {
+	defer c.lock.Unlock()
+	c.lock.Lock()
+	if c.inner.Len() >= c.maxSize {
+		return false, true
+	}
+	evicted = c.inner.Add(key, value)
+	if c.m != nil {
+		c.m.CacheAdd(c.label, c.inner.Len(), evicted)
+	}
+	return evicted, false
+}
+
 // NewLRUCache creates a LRU cache with the given metrics, labeling the cache adds/gets.
 // Metrics are optional: no metrics will be tracked if m == nil.
 func NewLRUCache(m Metrics, label string, maxSize int) *LRUCache {
 	// no errors if the size is positive
 	cache, _ := lru.New(maxSize)
 	return &LRUCache{
-		m:     m,
-		label: label,
-		inner: cache,
+		m:       m,
+		label:   label,
+		inner:   cache,
+		maxSize: maxSize,
 	}
 }

--- a/op-node/sources/caching/cache.go
+++ b/op-node/sources/caching/cache.go
@@ -1,8 +1,6 @@
 package caching
 
 import (
-	"sync"
-
 	lru "github.com/hashicorp/golang-lru"
 )
 
@@ -13,11 +11,9 @@ type Metrics interface {
 
 // LRUCache wraps hashicorp *lru.Cache and tracks cache metrics
 type LRUCache struct {
-	m       Metrics
-	label   string
-	inner   *lru.Cache
-	lock    sync.Mutex
-	maxSize int
+	m     Metrics
+	label string
+	inner *lru.Cache
 }
 
 func (c *LRUCache) Get(key any) (value any, ok bool) {
@@ -36,55 +32,14 @@ func (c *LRUCache) Add(key, value any) (evicted bool) {
 	return evicted
 }
 
-func (c *LRUCache) Peek(key any) (value any, ok bool) {
-	defer c.lock.Unlock()
-	c.lock.Lock()
-	return c.inner.Peek(key)
-}
-
-func (c *LRUCache) PeekAndCleanOld(key any) (value any, ok bool) {
-	defer c.lock.Unlock()
-	c.lock.Lock()
-	value, ok = c.inner.Peek(key)
-	if c.m != nil {
-		c.m.CacheGet(c.label, ok)
-	}
-	if ok {
-		for {
-			//Remove all elements older than the current element, as when retrieving that element, all elements older than it should have expired.
-			oKey, _, oOk := c.inner.GetOldest()
-			if oOk && oKey != key {
-				c.inner.RemoveOldest()
-				continue
-			}
-			break
-		}
-	}
-	return value, ok
-}
-
-func (c *LRUCache) AddIfNotFull(key, value any) (evicted bool, full bool) {
-	defer c.lock.Unlock()
-	c.lock.Lock()
-	if c.inner.Len() >= c.maxSize {
-		return false, true
-	}
-	evicted = c.inner.Add(key, value)
-	if c.m != nil {
-		c.m.CacheAdd(c.label, c.inner.Len(), evicted)
-	}
-	return evicted, false
-}
-
 // NewLRUCache creates a LRU cache with the given metrics, labeling the cache adds/gets.
 // Metrics are optional: no metrics will be tracked if m == nil.
 func NewLRUCache(m Metrics, label string, maxSize int) *LRUCache {
 	// no errors if the size is positive
 	cache, _ := lru.New(maxSize)
 	return &LRUCache{
-		m:       m,
-		label:   label,
-		inner:   cache,
-		maxSize: maxSize,
+		m:     m,
+		label: label,
+		inner: cache,
 	}
 }

--- a/op-node/sources/caching/pre_fetch_cache.go
+++ b/op-node/sources/caching/pre_fetch_cache.go
@@ -1,0 +1,90 @@
+package caching
+
+import (
+	"sync"
+
+	"github.com/ethereum/go-ethereum/common/prque"
+)
+
+type PreFetchCache[V any] struct {
+	m       Metrics
+	label   string
+	inner   map[uint64]V
+	queue   *prque.Prque[uint64, V]
+	lock    sync.Mutex
+	maxSize int
+}
+
+func NewPreFetchCache[V any](m Metrics, label string, maxSize int) *PreFetchCache[V] {
+	return &PreFetchCache[V]{
+		m:       m,
+		label:   label,
+		inner:   make(map[uint64]V),
+		queue:   prque.New[uint64, V](nil),
+		maxSize: maxSize,
+	}
+}
+
+func (v *PreFetchCache[V]) Add(key uint64, value V) bool {
+	defer v.lock.Unlock()
+	v.lock.Lock()
+	if _, ok := v.inner[key]; ok {
+		return false
+	}
+	v.queue.Push(value, -key)
+	v.inner[key] = value
+	if v.m != nil {
+		v.m.CacheAdd(v.label, v.queue.Size(), false)
+	}
+	return true
+}
+
+func (v *PreFetchCache[V]) AddIfNotFull(key uint64, value V) (success bool, isFull bool) {
+	defer v.lock.Unlock()
+	v.lock.Lock()
+	if _, ok := v.inner[key]; ok {
+		return false, false
+	}
+	if v.queue.Size() >= v.maxSize {
+		return false, true
+	}
+	v.queue.Push(value, -key)
+	v.inner[key] = value
+	if v.m != nil {
+		v.m.CacheAdd(v.label, v.queue.Size(), false)
+	}
+	return true, false
+}
+
+func (v *PreFetchCache[V]) Get(key uint64) (V, bool) {
+	defer v.lock.Unlock()
+	v.lock.Lock()
+	value, ok := v.inner[key]
+	if v.m != nil {
+		v.m.CacheGet(v.label, ok)
+	}
+	return value, ok
+}
+
+func (v *PreFetchCache[V]) RemoveAll() {
+	defer v.lock.Unlock()
+	v.lock.Lock()
+	v.inner = make(map[uint64]V)
+	v.queue.Reset()
+}
+
+func (v *PreFetchCache[V]) RemoveLessThan(p uint64) (isRemoved bool) {
+	defer v.lock.Unlock()
+	v.lock.Lock()
+	for !v.queue.Empty() {
+		_, qKey := v.queue.Peek()
+		if -qKey < p {
+			v.queue.Pop()
+			delete(v.inner, -qKey)
+			isRemoved = true
+			continue
+		}
+		break
+	}
+	return
+}

--- a/op-node/sources/eth_client.go
+++ b/op-node/sources/eth_client.go
@@ -370,13 +370,10 @@ func (s *EthClient) fetchReceiptsInner(ctx context.Context, blockHash common.Has
 	// that if just one of many calls fail, we only retry the failed call rather than all of the calls.
 	// The underlying fetcher uses the receipts hash to verify receipt integrity.
 	var job *receiptsFetchingJob
-	var v any
-	var ok bool
 	var isFull bool
-	v, ok = s.receiptsCache.Get(info.NumberU64())
-	pair, pairOk := v.(*receiptsFetchingJobPair)
-	if ok && pairOk && pair.blockHash == blockHash {
-		job = pair.job
+	v, ok := s.receiptsCache.Get(info.NumberU64())
+	if ok && v.blockHash == blockHash {
+		job = v.job
 	} else {
 		txHashes := eth.TransactionsToHashes(txs)
 		job = NewReceiptsFetchingJob(s, s.client, s.maxBatchSize, eth.ToBlockID(info), info.ReceiptHash(), txHashes)

--- a/op-node/sources/l1_client.go
+++ b/op-node/sources/l1_client.go
@@ -162,8 +162,9 @@ func (s *L1Client) GoOrUpdatePreFetchReceipts(ctx context.Context, l1Start uint6
 					}
 
 					var taskCount int
-					if blockRef.Number-currentL1Block >= uint64(s.maxConcurrentRequests) {
-						taskCount = s.maxConcurrentRequests
+					maxConcurrent := s.maxConcurrentRequests / 2
+					if blockRef.Number-currentL1Block >= uint64(maxConcurrent) {
+						taskCount = maxConcurrent
 					} else {
 						taskCount = int(blockRef.Number-currentL1Block) + 1
 					}

--- a/op-node/sources/receipts.go
+++ b/op-node/sources/receipts.go
@@ -359,6 +359,11 @@ type rpcClient interface {
 	BatchCallContext(ctx context.Context, b []rpc.BatchElem) error
 }
 
+type receiptsFetchingJobPair struct {
+	blockHash common.Hash
+	job       *receiptsFetchingJob
+}
+
 // receiptsFetchingJob runs the receipt fetching for a specific block,
 // and can re-run and adapt based on the fetching method preferences and errors communicated with the requester.
 type receiptsFetchingJob struct {

--- a/op-node/testutils/mock_eth_client.go
+++ b/op-node/testutils/mock_eth_client.go
@@ -101,6 +101,11 @@ func (m *MockEthClient) FetchReceipts(ctx context.Context, blockHash common.Hash
 	return *out[0].(*eth.BlockInfo), out[1].(types.Receipts), *out[2].(*error)
 }
 
+func (m *MockEthClient) PreFetchReceipts(ctx context.Context, blockHash common.Hash) (bool, error) {
+	out := m.Mock.MethodCalled("PreFetchReceipts", blockHash)
+	return *out[0].(*bool), *out[1].(*error)
+}
+
 func (m *MockEthClient) ExpectFetchReceipts(hash common.Hash, info eth.BlockInfo, receipts types.Receipts, err error) {
 	m.Mock.On("FetchReceipts", hash).Once().Return(&info, receipts, &err)
 }

--- a/op-node/testutils/mock_l1.go
+++ b/op-node/testutils/mock_l1.go
@@ -50,3 +50,7 @@ func (m *MockL1Source) ExpectGoOrUpdatePreFetchReceipts(background context.Conte
 func (m *MockL1Source) ClearReceiptsCacheBefore(blockNumber uint64) {
 	m.Mock.MethodCalled("ClearReceiptsCacheBefore", blockNumber)
 }
+
+func (m *MockL1Source) ExpectClearReceiptsCacheBefore(blockNumber uint64) {
+	m.Mock.On("ClearReceiptsCacheBefore", blockNumber).Once()
+}

--- a/op-node/testutils/mock_l1.go
+++ b/op-node/testutils/mock_l1.go
@@ -46,3 +46,7 @@ func (m *MockL1Source) GoOrUpdatePreFetchReceipts(ctx context.Context, l1StartBl
 func (m *MockL1Source) ExpectGoOrUpdatePreFetchReceipts(background context.Context, number uint64, err error) {
 	m.Mock.On("GoOrUpdatePreFetchReceipts", background, number).Once().Return(&err)
 }
+
+func (m *MockL1Source) ClearReceiptsCacheBefore(blockNumber uint64) {
+	m.Mock.MethodCalled("ClearReceiptsCacheBefore", blockNumber)
+}

--- a/op-program/client/l1/client.go
+++ b/op-program/client/l1/client.go
@@ -88,3 +88,7 @@ func (o *OracleL1Client) InfoAndTxsByHash(ctx context.Context, hash common.Hash)
 func (o *OracleL1Client) GoOrUpdatePreFetchReceipts(ctx context.Context, l1StartBlock uint64) error {
 	return o.oracle.GoOrUpdatePreFetchReceipts(ctx, l1StartBlock)
 }
+
+func (o *OracleL1Client) ClearReceiptsCacheBefore(blockNumber uint64) {
+	//do nothing
+}

--- a/op-program/client/l1/client.go
+++ b/op-program/client/l1/client.go
@@ -76,6 +76,10 @@ func (o *OracleL1Client) FetchReceipts(ctx context.Context, blockHash common.Has
 	return info, rcpts, nil
 }
 
+func (o *OracleL1Client) PreFetchReceipts(ctx context.Context, blockHash common.Hash) (bool, error) {
+	return false, nil
+}
+
 func (o *OracleL1Client) InfoAndTxsByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, types.Transactions, error) {
 	info, txs := o.oracle.TransactionsByBlockHash(hash)
 	return info, txs, nil

--- a/op-program/host/prefetcher/prefetcher.go
+++ b/op-program/host/prefetcher/prefetcher.go
@@ -23,6 +23,7 @@ type L1Source interface {
 	InfoByHash(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, error)
 	InfoAndTxsByHash(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Transactions, error)
 	FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error)
+	PreFetchReceipts(ctx context.Context, blockHash common.Hash) (bool, error)
 }
 
 type L2Source interface {


### PR DESCRIPTION
### Description
I implemented the first version of concurrent code to pre-fetch receipts at https://github.com/bnb-chain/opbnb/pull/100, but there are some problems that need to be fixed. Our cache is an LRU cache with a maximum capacity of 1000 items. When the goroutine implementation is changed to concurrent, the maximum capacity is quickly reached. This leads to the following problems:
1. Since the cache is LRU, the Get method will insert data of old blocks that were about to be evicted into the front of the queue, causing a large amount of useless data to accumulate in the cache while useful data is pushed out.
2. Concurrency makes it very easy for the cache to become full, resulting in old block data being quickly evicted and the cache becoming ineffective.

### Rationale
I made some changes. In the pre-fetched goroutine, I removed the rateLimit and used waitGroup instead. I also added the `PreFetchReceipts` method, which indicates whether the cache has been filled. If it is filled, the pre-fetched goroutine will wait and retry.
At the same time, I abandoned the LRU cache data structure because it does not meet the requirements of pre-fetch. We need to evict receipts data from memory when the corresponding L1 block height is used up. Therefore, a priority queue sorted by block height from smallest to largest is a better choice. I created a new data structure called preFetchCache to cache receipts data. This structure is composed of a map and a priority queue, it will assist pre-fetch in deleting old block height receipts data at the appropriate time.
So when is the appropriate time to delete receipt data? I inserted the method `ClearReceiptsCacheBefore` into `postProcessSafeL2` because when the safe block height processing is completed, it means that the corresponding L1 original block height receipt data is no longer needed. To be more cautious, we only delete data that is lower than the block height, without including it.

### Example

none

### Changes

Notable changes:
* Changed the logic in `GoOrUpdatePreFetchReceipts`, using waitGroup instead of rateLimit.
* Added `PreFetchReceipts` method, replacing `FetchReceipts` in `GoOrUpdatePreFetchReceipts`.
* Added the preFetchCache structure, replacing the original LRU, making it easier to eliminate old data.
