### PR TITLE
optimize: extended expire time for sequencer block broadcasting

### DIFF
--- a/op-node/p2p/gossip.go
+++ b/op-node/p2p/gossip.go
@@ -34,8 +34,8 @@ const (
 	globalValidateThrottle = 512
 	gossipHeartbeat        = 500 * time.Millisecond
 	// seenMessagesTTL limits the duration that message IDs are remembered for gossip deduplication purposes
-	// 130 * gossipHeartbeat
-	seenMessagesTTL  = 130 * gossipHeartbeat
+	// 2500 * gossipHeartbeat
+	seenMessagesTTL  = 2500 * gossipHeartbeat
 	DefaultMeshD     = 8  // topic stable mesh target count
 	DefaultMeshDlo   = 6  // topic stable mesh low watermark
 	DefaultMeshDhi   = 12 // topic stable mesh high watermark
@@ -242,7 +242,7 @@ func BuildBlocksValidator(log log.Logger, cfg *rollup.Config, runCfg GossipRunti
 
 	// Seen block hashes per block height
 	// uint64 -> *seenBlocks
-	blockHeightLRU, err := lru.New(1000)
+	blockHeightLRU, err := lru.New(1500)
 	if err != nil {
 		panic(fmt.Errorf("failed to set up block height LRU cache: %w", err))
 	}

--- a/op-node/p2p/gossip.go
+++ b/op-node/p2p/gossip.go
@@ -291,8 +291,8 @@ func BuildBlocksValidator(log log.Logger, cfg *rollup.Config, runCfg GossipRunti
 		// rounding down to seconds is fine here.
 		now := uint64(time.Now().Unix())
 
-		// [REJECT] if the `payload.timestamp` is older than 60 seconds in the past
-		if uint64(payload.Timestamp) < now-60 {
+		// [REJECT] if the `payload.timestamp` is older than 20 min in the past
+		if uint64(payload.Timestamp) < now-1200 {
 			log.Warn("payload is too old", "timestamp", uint64(payload.Timestamp))
 			return pubsub.ValidationReject
 		}


### PR DESCRIPTION
### Description

This PR incorporates modifications to the block validator within the op-node, which is utilized by both the sender (sequencer) and receiver. The block expiration check has been increased from 60 seconds to 20 minutes. This change was prompted by scenarios where the sequencer could not maintain a block production rate of one block per second. Under the previous validation logic, if blocks were produced slowly for a period and the anticipated block time was more than 60 seconds apart from the current time, the sequencer would fail the check and be unable to broadcast the block, preventing other nodes from syncing unsafe blocks. With this change, the time has been increased to 20 minutes. Please note that the 20-minute duration is not the time we maintain synchronization, but a relative time difference. (For example, if the sequencer’s block production speed drops to half, at 2 seconds per block, then the actual duration for which the sequencer continues broadcasting blocks would be approximately 40 minutes.)

### Rationale
Two adjustments have been made:
1.The time duration within the block validator has been extended from 60s to 20min.
2.Enhancements were made to the seenMessagesTTL and blockHeightLRU caches to guard against potential stale block attacks that could arise due to the validator changes. The seenMessagesTTL serves as a preliminary logic cache before entering the validator, where a block hitting this cache would not proceed to further validation and processing. The blockHeightLRU cache is used to keep track of the number of validations for duplicate blocks to signal other nodes with an 'ignore' or 'reject'. As our validation effective time has increased from 1 minute to 20 minutes, the corresponding caches also required expansion to prevent possible block broadcast attacks.

### Example

N/A

### Changes

Notable changes:
* BuildBlocksValidator config change
* seenMessagesTTL and blockHeightLRU extended
