### PR TITLE
feat(op-batcher/op-proposer): add InstrumentedClient

### DIFF
--- a/op-batcher/batcher/config.go
+++ b/op-batcher/batcher/config.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-service/client"
 
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/urfave/cli"
 
@@ -25,7 +24,7 @@ type Config struct {
 	log        log.Logger
 	metr       metrics.Metricer
 	L1Client   client.EthClient
-	L2Client   *ethclient.Client
+	L2Client   client.EthClient
 	RollupNode *sources.RollupClient
 	TxManager  txmgr.TxManager
 

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -57,11 +57,13 @@ func NewBatchSubmitterFromCLIConfig(cfg CLIConfig, l log.Logger, m metrics.Metri
 	if err != nil {
 		return nil, err
 	}
+	l1Client = opclient.NewInstrumentedClient(l1Client, m)
 
 	l2Client, err := opclient.DialEthClientWithTimeout(ctx, cfg.L2EthRpc, opclient.DefaultDialTimeout)
 	if err != nil {
 		return nil, err
 	}
+	l2Client = opclient.NewInstrumentedClient(l2Client, m)
 
 	rollupClient, err := opclient.DialRollupClientWithTimeout(ctx, cfg.RollupRpc, opclient.DefaultDialTimeout)
 	if err != nil {

--- a/op-batcher/metrics/metrics.go
+++ b/op-batcher/metrics/metrics.go
@@ -2,8 +2,12 @@ package metrics
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
+	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -17,6 +21,7 @@ import (
 )
 
 const Namespace = "op_batcher"
+const RPCClientSubsystem = "rpc_client"
 
 type Metricer interface {
 	RecordInfo(version string)
@@ -43,6 +48,7 @@ type Metricer interface {
 	RecordBatchTxFailed()
 
 	Document() []opmetrics.DocumentedMetric
+	client.Metricer
 }
 
 type Metrics struct {
@@ -74,6 +80,10 @@ type Metrics struct {
 	channelOutputBytesTotal prometheus.Counter
 
 	batcherTxEvs opmetrics.EventVec
+
+	RPCClientRequestsTotal          *prometheus.CounterVec
+	RPCClientRequestDurationSeconds *prometheus.HistogramVec
+	RPCClientResponsesTotal         *prometheus.CounterVec
 }
 
 var _ Metricer = (*Metrics)(nil)
@@ -174,6 +184,33 @@ func NewMetrics(procName string) *Metrics {
 		}),
 
 		batcherTxEvs: opmetrics.NewEventVec(factory, ns, "", "batcher_tx", "BatcherTx", []string{"stage"}),
+
+		RPCClientRequestsTotal: factory.NewCounterVec(prometheus.CounterOpts{
+			Namespace: ns,
+			Subsystem: RPCClientSubsystem,
+			Name:      "requests_total",
+			Help:      "Total RPC requests initiated by the op-batcher's RPC client",
+		}, []string{
+			"method",
+		}),
+		RPCClientRequestDurationSeconds: factory.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: ns,
+			Subsystem: RPCClientSubsystem,
+			Name:      "request_duration_seconds",
+			Buckets:   []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
+			Help:      "Histogram of RPC client request durations",
+		}, []string{
+			"method",
+		}),
+		RPCClientResponsesTotal: factory.NewCounterVec(prometheus.CounterOpts{
+			Namespace: ns,
+			Subsystem: RPCClientSubsystem,
+			Name:      "responses_total",
+			Help:      "Total RPC request responses received by the op-batcher's RPC client",
+		}, []string{
+			"method",
+			"error",
+		}),
 	}
 }
 
@@ -294,6 +331,39 @@ func (m *Metrics) RecordBatchTxSuccess() {
 
 func (m *Metrics) RecordBatchTxFailed() {
 	m.batcherTxEvs.Record(TxStageFailed)
+}
+
+func (m *Metrics) RecordRPCClientRequest(method string) func(err error) {
+	m.RPCClientRequestsTotal.WithLabelValues(method).Inc()
+	timer := prometheus.NewTimer(m.RPCClientRequestDurationSeconds.WithLabelValues(method))
+	return func(err error) {
+		m.RecordRPCClientResponse(method, err)
+		timer.ObserveDuration()
+	}
+}
+
+// RecordRPCClientResponse records an RPC response. It will
+// convert the passed-in error into something metrics friendly.
+// Nil errors get converted into <nil>, RPC errors are converted
+// into rpc_<error code>, HTTP errors are converted into
+// http_<status code>, and everything else is converted into
+// <unknown>.
+func (m *Metrics) RecordRPCClientResponse(method string, err error) {
+	var errStr string
+	var rpcErr rpc.Error
+	var httpErr rpc.HTTPError
+	if err == nil {
+		errStr = "<nil>"
+	} else if errors.As(err, &rpcErr) {
+		errStr = fmt.Sprintf("rpc_%d", rpcErr.ErrorCode())
+	} else if errors.As(err, &httpErr) {
+		errStr = fmt.Sprintf("http_%d", httpErr.StatusCode)
+	} else if errors.Is(err, ethereum.NotFound) {
+		errStr = "<not found>"
+	} else {
+		errStr = "<unknown>"
+	}
+	m.RPCClientResponsesTotal.WithLabelValues(method, errStr).Inc()
 }
 
 // estimateBatchSize estimates the size of the batch

--- a/op-batcher/metrics/noop.go
+++ b/op-batcher/metrics/noop.go
@@ -40,5 +40,6 @@ func (m *noopMetrics) RecordL1UrlSwitchEvt(url string) {
 }
 
 func (m *noopMetrics) RecordRPCClientRequest(method string) func(err error) {
-	return nil
+	return func(err error) {
+	}
 }

--- a/op-batcher/metrics/noop.go
+++ b/op-batcher/metrics/noop.go
@@ -38,3 +38,7 @@ func (*noopMetrics) RecordBatchTxFailed()    {}
 
 func (m *noopMetrics) RecordL1UrlSwitchEvt(url string) {
 }
+
+func (m *noopMetrics) RecordRPCClientRequest(method string) func(err error) {
+	return nil
+}

--- a/op-proposer/metrics/metrics.go
+++ b/op-proposer/metrics/metrics.go
@@ -2,8 +2,12 @@ package metrics
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
+	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 
@@ -16,6 +20,7 @@ import (
 )
 
 const Namespace = "op_proposer"
+const RPCClientSubsystem = "rpc_client"
 
 type Metricer interface {
 	RecordInfo(version string)
@@ -28,6 +33,7 @@ type Metricer interface {
 	txmetrics.TxMetricer
 
 	RecordL2BlocksProposed(l2ref eth.L2BlockRef)
+	client.Metricer
 }
 
 type Metrics struct {
@@ -40,6 +46,10 @@ type Metrics struct {
 
 	info prometheus.GaugeVec
 	up   prometheus.Gauge
+
+	RPCClientRequestsTotal          *prometheus.CounterVec
+	RPCClientRequestDurationSeconds *prometheus.HistogramVec
+	RPCClientResponsesTotal         *prometheus.CounterVec
 }
 
 var _ Metricer = (*Metrics)(nil)
@@ -72,6 +82,32 @@ func NewMetrics(procName string) *Metrics {
 			Namespace: ns,
 			Name:      "up",
 			Help:      "1 if the op-proposer has finished starting up",
+		}),
+		RPCClientRequestsTotal: factory.NewCounterVec(prometheus.CounterOpts{
+			Namespace: ns,
+			Subsystem: RPCClientSubsystem,
+			Name:      "requests_total",
+			Help:      "Total RPC requests initiated by the op-proposer's RPC client",
+		}, []string{
+			"method",
+		}),
+		RPCClientRequestDurationSeconds: factory.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: ns,
+			Subsystem: RPCClientSubsystem,
+			Name:      "request_duration_seconds",
+			Buckets:   []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
+			Help:      "Histogram of RPC client request durations",
+		}, []string{
+			"method",
+		}),
+		RPCClientResponsesTotal: factory.NewCounterVec(prometheus.CounterOpts{
+			Namespace: ns,
+			Subsystem: RPCClientSubsystem,
+			Name:      "responses_total",
+			Help:      "Total RPC request responses received by the op-proposer's RPC client",
+		}, []string{
+			"method",
+			"error",
 		}),
 	}
 }
@@ -108,4 +144,37 @@ func (m *Metrics) RecordL2BlocksProposed(l2ref eth.L2BlockRef) {
 
 func (m *Metrics) Document() []opmetrics.DocumentedMetric {
 	return m.factory.Document()
+}
+
+func (m *Metrics) RecordRPCClientRequest(method string) func(err error) {
+	m.RPCClientRequestsTotal.WithLabelValues(method).Inc()
+	timer := prometheus.NewTimer(m.RPCClientRequestDurationSeconds.WithLabelValues(method))
+	return func(err error) {
+		m.RecordRPCClientResponse(method, err)
+		timer.ObserveDuration()
+	}
+}
+
+// RecordRPCClientResponse records an RPC response. It will
+// convert the passed-in error into something metrics friendly.
+// Nil errors get converted into <nil>, RPC errors are converted
+// into rpc_<error code>, HTTP errors are converted into
+// http_<status code>, and everything else is converted into
+// <unknown>.
+func (m *Metrics) RecordRPCClientResponse(method string, err error) {
+	var errStr string
+	var rpcErr rpc.Error
+	var httpErr rpc.HTTPError
+	if err == nil {
+		errStr = "<nil>"
+	} else if errors.As(err, &rpcErr) {
+		errStr = fmt.Sprintf("rpc_%d", rpcErr.ErrorCode())
+	} else if errors.As(err, &httpErr) {
+		errStr = fmt.Sprintf("http_%d", httpErr.StatusCode)
+	} else if errors.Is(err, ethereum.NotFound) {
+		errStr = "<not found>"
+	} else {
+		errStr = "<unknown>"
+	}
+	m.RPCClientResponsesTotal.WithLabelValues(method, errStr).Inc()
 }

--- a/op-proposer/metrics/noop.go
+++ b/op-proposer/metrics/noop.go
@@ -20,3 +20,7 @@ func (*noopMetrics) RecordL2BlocksProposed(l2ref eth.L2BlockRef) {}
 
 func (m *noopMetrics) RecordL1UrlSwitchEvt(url string) {
 }
+
+func (m *noopMetrics) RecordRPCClientRequest(method string) func(err error) {
+	return nil
+}

--- a/op-proposer/metrics/noop.go
+++ b/op-proposer/metrics/noop.go
@@ -22,5 +22,6 @@ func (m *noopMetrics) RecordL1UrlSwitchEvt(url string) {
 }
 
 func (m *noopMetrics) RecordRPCClientRequest(method string) func(err error) {
-	return nil
+	return func(err error) {
+	}
 }

--- a/op-proposer/proposer/l2_output_submitter.go
+++ b/op-proposer/proposer/l2_output_submitter.go
@@ -162,6 +162,7 @@ func NewL2OutputSubmitterConfigFromCLIConfig(cfg CLIConfig, l log.Logger, m metr
 	if err != nil {
 		return nil, err
 	}
+	l1Client = opclient.NewInstrumentedClient(l1Client, m)
 
 	rollupClient, err := opclient.DialRollupClientWithTimeout(ctx, cfg.RollupRpc, opclient.DefaultDialTimeout)
 	if err != nil {

--- a/op-service/client/ethclient.go
+++ b/op-service/client/ethclient.go
@@ -2,12 +2,13 @@ package client
 
 import (
 	"context"
+	"math/big"
+	"time"
+
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
-	"math/big"
-	"time"
 
 	"github.com/ethereum/go-ethereum/ethclient"
 )
@@ -15,7 +16,7 @@ import (
 // DialEthClientWithTimeout attempts to dial the L1 provider using the provided
 // URL. If the dial doesn't complete within defaultDialTimeout seconds, this
 // method will return an error.
-func DialEthClientWithTimeout(ctx context.Context, url string, timeout time.Duration) (*ethclient.Client, error) {
+func DialEthClientWithTimeout(ctx context.Context, url string, timeout time.Duration) (EthClient, error) {
 	ctxt, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
@@ -66,5 +67,6 @@ type EthClient interface {
 	PendingNonceAt(ctx context.Context, account common.Address) (uint64, error)
 	EstimateGas(ctx context.Context, msg ethereum.CallMsg) (uint64, error)
 	CallContract(ctx context.Context, call ethereum.CallMsg, blockNumber *big.Int) ([]byte, error)
+	BlockByNumber(ctx context.Context, number *big.Int) (*types.Block, error)
 	Close()
 }

--- a/op-service/client/fallback_client.go
+++ b/op-service/client/fallback_client.go
@@ -152,6 +152,14 @@ func (l *FallbackClient) CallContract(ctx context.Context, call ethereum.CallMsg
 	return contract, err
 }
 
+func (l *FallbackClient) BlockByNumber(ctx context.Context, number *big.Int) (*types.Block, error) {
+	block, err := (*l.currentClient.Load()).BlockByNumber(ctx, number)
+	if err != nil {
+		l.handleErr(err, "BlockByNumber")
+	}
+	return block, err
+}
+
 func (l *FallbackClient) Close() {
 	l.mx.Lock()
 	defer l.mx.Unlock()

--- a/op-service/client/metrics.go
+++ b/op-service/client/metrics.go
@@ -21,7 +21,7 @@ type Metricer interface {
 }
 
 // NewInstrumentedClient creates a new instrumented client. It takes
-// a concrete *rpc.Client to prevent people from passing in an already
+// a concrete EthClient to prevent people from passing in an already
 // instrumented client.
 func NewInstrumentedClient(c EthClient, m Metricer) EthClient {
 	return &InstrumentedClient{

--- a/op-service/client/metrics.go
+++ b/op-service/client/metrics.go
@@ -1,0 +1,133 @@
+package client
+
+import (
+	"context"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// InstrumentedClient is an Ethereum client that tracks
+// Prometheus metrics for each call.
+type InstrumentedClient struct {
+	c EthClient
+	m Metricer
+}
+
+type Metricer interface {
+	RecordRPCClientRequest(method string) func(err error)
+}
+
+// NewInstrumentedClient creates a new instrumented client. It takes
+// a concrete *rpc.Client to prevent people from passing in an already
+// instrumented client.
+func NewInstrumentedClient(c EthClient, m Metricer) EthClient {
+	return &InstrumentedClient{
+		c: c,
+		m: m,
+	}
+}
+
+func (ic *InstrumentedClient) Close() {
+	ic.c.Close()
+}
+
+func (ic *InstrumentedClient) ChainID(ctx context.Context) (*big.Int, error) {
+	return instrument2[*big.Int](ic.m, "eth_chainId", func() (*big.Int, error) {
+		return ic.c.ChainID(ctx)
+	})
+}
+
+func (ic *InstrumentedClient) BlockNumber(ctx context.Context) (uint64, error) {
+	return instrument2[uint64](ic.m, "eth_blockNumber", func() (uint64, error) {
+		return ic.c.BlockNumber(ctx)
+	})
+}
+
+func (ic *InstrumentedClient) HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error) {
+	return instrument2[*types.Header](ic.m, "eth_getHeaderByNumber", func() (*types.Header, error) {
+		return ic.c.HeaderByNumber(ctx, number)
+	})
+}
+
+func (ic *InstrumentedClient) TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
+	return instrument2[*types.Receipt](ic.m, "eth_getTransactionReceipt", func() (*types.Receipt, error) {
+		return ic.c.TransactionReceipt(ctx, txHash)
+	})
+}
+
+func (ic *InstrumentedClient) BalanceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (*big.Int, error) {
+	return instrument2[*big.Int](ic.m, "eth_getBalance", func() (*big.Int, error) {
+		return ic.c.BalanceAt(ctx, account, blockNumber)
+	})
+}
+
+func (ic *InstrumentedClient) StorageAt(ctx context.Context, account common.Address, key common.Hash, blockNumber *big.Int) ([]byte, error) {
+	return instrument2[[]byte](ic.m, "eth_getStorageAt", func() ([]byte, error) {
+		return ic.c.StorageAt(ctx, account, key, blockNumber)
+	})
+}
+
+func (ic *InstrumentedClient) CodeAt(ctx context.Context, account common.Address, blockNumber *big.Int) ([]byte, error) {
+	return instrument2[[]byte](ic.m, "eth_getCode", func() ([]byte, error) {
+		return ic.c.CodeAt(ctx, account, blockNumber)
+	})
+}
+
+func (ic *InstrumentedClient) NonceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (uint64, error) {
+	return instrument2[uint64](ic.m, "eth_getTransactionCount", func() (uint64, error) {
+		return ic.c.NonceAt(ctx, account, blockNumber)
+	})
+}
+
+func (ic *InstrumentedClient) PendingNonceAt(ctx context.Context, account common.Address) (uint64, error) {
+	return instrument2[uint64](ic.m, "eth_getTransactionCount", func() (uint64, error) {
+		return ic.c.PendingNonceAt(ctx, account)
+	})
+}
+
+func (ic *InstrumentedClient) CallContract(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+	return instrument2[[]byte](ic.m, "eth_call", func() ([]byte, error) {
+		return ic.c.CallContract(ctx, msg, blockNumber)
+	})
+}
+
+func (ic *InstrumentedClient) EstimateGas(ctx context.Context, msg ethereum.CallMsg) (uint64, error) {
+	return instrument2[uint64](ic.m, "eth_estimateGas", func() (uint64, error) {
+		return ic.c.EstimateGas(ctx, msg)
+	})
+}
+
+func (ic *InstrumentedClient) SendTransaction(ctx context.Context, tx *types.Transaction) error {
+	return instrument1(ic.m, "eth_sendRawTransaction", func() error {
+		return ic.c.SendTransaction(ctx, tx)
+	})
+}
+
+func (ic *InstrumentedClient) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
+	return instrument2[*big.Int](ic.m, "eth_maxPriorityFeePerGas", func() (*big.Int, error) {
+		return ic.c.SuggestGasTipCap(ctx)
+	})
+}
+
+func (ic *InstrumentedClient) BlockByNumber(ctx context.Context, number *big.Int) (*types.Block, error) {
+	return instrument2[*types.Block](ic.m, "eth_getBlockByNumber", func() (*types.Block, error) {
+		return ic.c.BlockByNumber(ctx, number)
+	})
+}
+
+func instrument1(m Metricer, name string, cb func() error) error {
+	record := m.RecordRPCClientRequest(name)
+	err := cb()
+	record(err)
+	return err
+}
+
+func instrument2[O any](m Metricer, name string, cb func() (O, error)) (O, error) {
+	record := m.RecordRPCClientRequest(name)
+	res, err := cb()
+	record(err)
+	return res, err
+}

--- a/op-service/txmgr/cli.go
+++ b/op-service/txmgr/cli.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	txmetrics "github.com/ethereum-optimism/optimism/op-service/txmgr/metrics"
 	"math/big"
 	"time"
+
+	txmetrics "github.com/ethereum-optimism/optimism/op-service/txmgr/metrics"
 
 	opservice "github.com/ethereum-optimism/optimism/op-service"
 	service_client "github.com/ethereum-optimism/optimism/op-service/client"
@@ -186,6 +187,7 @@ func NewConfig(cfg CLIConfig, l log.Logger, m txmetrics.TxMetricer) (Config, err
 	if err != nil {
 		return Config{}, fmt.Errorf("could not dial eth client: %w", err)
 	}
+	l1 = service_client.NewInstrumentedClient(l1, m)
 
 	ctx, cancel = context.WithTimeout(context.Background(), cfg.NetworkTimeout)
 	defer cancel()

--- a/op-service/txmgr/metrics/noop.go
+++ b/op-service/txmgr/metrics/noop.go
@@ -4,12 +4,15 @@ import "github.com/ethereum/go-ethereum/core/types"
 
 type NoopTxMetrics struct{}
 
-func (*NoopTxMetrics) RecordNonce(uint64)                                     {}
-func (*NoopTxMetrics) RecordPendingTx(int64)                                  {}
-func (*NoopTxMetrics) RecordGasBumpCount(int)                                 {}
-func (*NoopTxMetrics) RecordTxConfirmationLatency(int64)                      {}
-func (*NoopTxMetrics) TxConfirmed(*types.Receipt)                             {}
-func (*NoopTxMetrics) TxPublished(string)                                     {}
-func (*NoopTxMetrics) RPCError()                                              {}
-func (m *NoopTxMetrics) RecordL1UrlSwitchEvt(url string)                      {}
-func (m *NoopTxMetrics) RecordRPCClientRequest(method string) func(err error) { return nil }
+func (*NoopTxMetrics) RecordNonce(uint64)                {}
+func (*NoopTxMetrics) RecordPendingTx(int64)             {}
+func (*NoopTxMetrics) RecordGasBumpCount(int)            {}
+func (*NoopTxMetrics) RecordTxConfirmationLatency(int64) {}
+func (*NoopTxMetrics) TxConfirmed(*types.Receipt)        {}
+func (*NoopTxMetrics) TxPublished(string)                {}
+func (*NoopTxMetrics) RPCError()                         {}
+func (m *NoopTxMetrics) RecordL1UrlSwitchEvt(url string) {}
+func (m *NoopTxMetrics) RecordRPCClientRequest(method string) func(err error) {
+	return func(err error) {
+	}
+}

--- a/op-service/txmgr/metrics/noop.go
+++ b/op-service/txmgr/metrics/noop.go
@@ -4,11 +4,12 @@ import "github.com/ethereum/go-ethereum/core/types"
 
 type NoopTxMetrics struct{}
 
-func (*NoopTxMetrics) RecordNonce(uint64)                {}
-func (*NoopTxMetrics) RecordPendingTx(int64)             {}
-func (*NoopTxMetrics) RecordGasBumpCount(int)            {}
-func (*NoopTxMetrics) RecordTxConfirmationLatency(int64) {}
-func (*NoopTxMetrics) TxConfirmed(*types.Receipt)        {}
-func (*NoopTxMetrics) TxPublished(string)                {}
-func (*NoopTxMetrics) RPCError()                         {}
-func (m *NoopTxMetrics) RecordL1UrlSwitchEvt(url string) {}
+func (*NoopTxMetrics) RecordNonce(uint64)                                     {}
+func (*NoopTxMetrics) RecordPendingTx(int64)                                  {}
+func (*NoopTxMetrics) RecordGasBumpCount(int)                                 {}
+func (*NoopTxMetrics) RecordTxConfirmationLatency(int64)                      {}
+func (*NoopTxMetrics) TxConfirmed(*types.Receipt)                             {}
+func (*NoopTxMetrics) TxPublished(string)                                     {}
+func (*NoopTxMetrics) RPCError()                                              {}
+func (m *NoopTxMetrics) RecordL1UrlSwitchEvt(url string)                      {}
+func (m *NoopTxMetrics) RecordRPCClientRequest(method string) func(err error) { return nil }

--- a/op-service/txmgr/metrics/tx_metrics.go
+++ b/op-service/txmgr/metrics/tx_metrics.go
@@ -1,10 +1,15 @@
 package metrics
 
 import (
+	"errors"
+	"fmt"
+
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/metrics"
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -18,20 +23,24 @@ type TxMetricer interface {
 	TxPublished(string)
 	RPCError()
 	client.FallbackClientMetricer
+	client.Metricer
 }
 
 type TxMetrics struct {
-	TxL1GasFee         prometheus.Gauge
-	txFees             prometheus.Counter
-	TxGasBump          prometheus.Gauge
-	txFeeHistogram     prometheus.Histogram
-	LatencyConfirmedTx prometheus.Gauge
-	currentNonce       prometheus.Gauge
-	pendingTxs         prometheus.Gauge
-	txPublishError     *prometheus.CounterVec
-	publishEvent       metrics.Event
-	confirmEvent       metrics.EventVec
-	rpcError           prometheus.Counter
+	TxL1GasFee                      prometheus.Gauge
+	txFees                          prometheus.Counter
+	TxGasBump                       prometheus.Gauge
+	txFeeHistogram                  prometheus.Histogram
+	LatencyConfirmedTx              prometheus.Gauge
+	currentNonce                    prometheus.Gauge
+	pendingTxs                      prometheus.Gauge
+	txPublishError                  *prometheus.CounterVec
+	publishEvent                    metrics.Event
+	confirmEvent                    metrics.EventVec
+	rpcError                        prometheus.Counter
+	RPCClientRequestsTotal          *prometheus.CounterVec
+	RPCClientRequestDurationSeconds *prometheus.HistogramVec
+	RPCClientResponsesTotal         *prometheus.CounterVec
 	*client.FallbackClientMetrics
 }
 
@@ -108,6 +117,32 @@ func MakeTxMetrics(ns string, factory metrics.Factory) TxMetrics {
 			Subsystem: "txmgr",
 		}),
 		FallbackClientMetrics: client.NewFallbackClientMetrics(ns, factory),
+		RPCClientRequestsTotal: factory.NewCounterVec(prometheus.CounterOpts{
+			Namespace: ns,
+			Subsystem: "txmgr_rpc_client",
+			Name:      "requests_total",
+			Help:      "Total RPC requests initiated by the txmgr's RPC client",
+		}, []string{
+			"method",
+		}),
+		RPCClientRequestDurationSeconds: factory.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: ns,
+			Subsystem: "txmgr_rpc_client",
+			Name:      "request_duration_seconds",
+			Buckets:   []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
+			Help:      "Histogram of RPC client request durations",
+		}, []string{
+			"method",
+		}),
+		RPCClientResponsesTotal: factory.NewCounterVec(prometheus.CounterOpts{
+			Namespace: ns,
+			Subsystem: "txmgr_rpc_client",
+			Name:      "responses_total",
+			Help:      "Total RPC request responses received by the txmgr's RPC client",
+		}, []string{
+			"method",
+			"error",
+		}),
 	}
 }
 
@@ -147,4 +182,37 @@ func (t *TxMetrics) TxPublished(errString string) {
 
 func (t *TxMetrics) RPCError() {
 	t.rpcError.Inc()
+}
+
+func (t *TxMetrics) RecordRPCClientRequest(method string) func(err error) {
+	t.RPCClientRequestsTotal.WithLabelValues(method).Inc()
+	timer := prometheus.NewTimer(t.RPCClientRequestDurationSeconds.WithLabelValues(method))
+	return func(err error) {
+		t.RecordRPCClientResponse(method, err)
+		timer.ObserveDuration()
+	}
+}
+
+// RecordRPCClientResponse records an RPC response. It will
+// convert the passed-in error into something metrics friendly.
+// Nil errors get converted into <nil>, RPC errors are converted
+// into rpc_<error code>, HTTP errors are converted into
+// http_<status code>, and everything else is converted into
+// <unknown>.
+func (t *TxMetrics) RecordRPCClientResponse(method string, err error) {
+	var errStr string
+	var rpcErr rpc.Error
+	var httpErr rpc.HTTPError
+	if err == nil {
+		errStr = "<nil>"
+	} else if errors.As(err, &rpcErr) {
+		errStr = fmt.Sprintf("rpc_%d", rpcErr.ErrorCode())
+	} else if errors.As(err, &httpErr) {
+		errStr = fmt.Sprintf("http_%d", httpErr.StatusCode)
+	} else if errors.Is(err, ethereum.NotFound) {
+		errStr = "<not found>"
+	} else {
+		errStr = "<unknown>"
+	}
+	t.RPCClientResponsesTotal.WithLabelValues(method, errStr).Inc()
 }


### PR DESCRIPTION
### Description
Currently neither op-batcher nor op-proposer has metrics related to RPC clients, so we cannot know the performance of requesting L1 and L2 endpoints. We need to solve this problem.

### Rationale

We add InstrumentedClient in op-service, which is responsible for collecting metrics for each method.

### Example
Example of new metrics:
op_batcher_default_rpc_client_requests_total
op_proposer_default_rpc_client_requests_total
op_batcher_default_rpc_client_request_duration_seconds_bucket
op_proposer_default_rpc_client_request_duration_seconds_bucket

### Changes

Notable changes:
* Added InstrumentedClient in op-service
* Replace the original EthClient with the newly added InstrumentedClient.
* Add necessary items to metrics in op-batcher and op-proposer.
