### PR TITLE
feat(op-node): pre-fetch block info and transaction

### DIFF
--- a/op-node/sources/caching/cache.go
+++ b/op-node/sources/caching/cache.go
@@ -22,13 +22,13 @@ func (c *LRUCache) Get(key any) (value any, ok bool) {
 	return value, ok
 }
 
-func (c *LRUCache) GetOrPeek(key any, usePeek bool) (value any, ok bool) {
+func (c *LRUCache) GetOrPeek(key any, usePeek bool, recordMetrics bool) (value any, ok bool) {
 	if usePeek {
 		value, ok = c.inner.Peek(key)
 	} else {
 		value, ok = c.inner.Get(key)
 	}
-	if c.m != nil {
+	if c.m != nil && recordMetrics {
 		c.m.CacheGet(c.label, ok)
 	}
 	return value, ok

--- a/op-node/sources/caching/cache.go
+++ b/op-node/sources/caching/cache.go
@@ -22,6 +22,18 @@ func (c *LRUCache) Get(key any) (value any, ok bool) {
 	return value, ok
 }
 
+func (c *LRUCache) GetOrPeek(key any, usePeek bool) (value any, ok bool) {
+	if usePeek {
+		value, ok = c.inner.Peek(key)
+	} else {
+		value, ok = c.inner.Get(key)
+	}
+	if c.m != nil {
+		c.m.CacheGet(c.label, ok)
+	}
+	return value, ok
+}
+
 func (c *LRUCache) Add(key, value any) (evicted bool) {
 	evicted = c.inner.Add(key, value)
 	if c.m != nil {

--- a/op-node/sources/caching/pre_fetch_cache.go
+++ b/op-node/sources/caching/pre_fetch_cache.go
@@ -56,11 +56,11 @@ func (v *PreFetchCache[V]) AddIfNotFull(key uint64, value V) (success bool, isFu
 	return true, false
 }
 
-func (v *PreFetchCache[V]) Get(key uint64) (V, bool) {
+func (v *PreFetchCache[V]) Get(key uint64, recordMetrics bool) (V, bool) {
 	defer v.lock.Unlock()
 	v.lock.Lock()
 	value, ok := v.inner[key]
-	if v.m != nil {
+	if v.m != nil && recordMetrics {
 		v.m.CacheGet(v.label, ok)
 	}
 	return value, ok

--- a/op-node/sources/eth_client.go
+++ b/op-node/sources/eth_client.go
@@ -296,7 +296,7 @@ func (s *EthClient) ChainID(ctx context.Context) (*big.Int, error) {
 }
 
 func (s *EthClient) InfoByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, error) {
-	if header, ok := s.headersCache.GetOrPeek(hash, s.isReadOrderly); ok {
+	if header, ok := s.headersCache.GetOrPeek(hash, s.isReadOrderly, true); ok {
 		return header.(eth.BlockInfo), nil
 	}
 	return s.headerCall(ctx, "eth_getBlockByHash", hashID(hash))
@@ -321,8 +321,12 @@ func (s *EthClient) BSCInfoByLabel(ctx context.Context, label eth.BlockLabel) (e
 }
 
 func (s *EthClient) InfoAndTxsByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, types.Transactions, error) {
-	if header, ok := s.headersCache.GetOrPeek(hash, s.isReadOrderly); ok {
-		if txs, ok := s.transactionsCache.GetOrPeek(hash, s.isReadOrderly); ok {
+	return s.infoAndTxsByHash(ctx, hash, true)
+}
+
+func (s *EthClient) infoAndTxsByHash(ctx context.Context, hash common.Hash, recordMetrics bool) (eth.BlockInfo, types.Transactions, error) {
+	if header, ok := s.headersCache.GetOrPeek(hash, s.isReadOrderly, recordMetrics); ok {
+		if txs, ok := s.transactionsCache.GetOrPeek(hash, s.isReadOrderly, recordMetrics); ok {
 			return header.(eth.BlockInfo), txs.(types.Transactions), nil
 		}
 	}
@@ -367,7 +371,7 @@ func (s *EthClient) FetchReceipts(ctx context.Context, blockHash common.Hash) (e
 }
 
 func (s *EthClient) fetchReceiptsInner(ctx context.Context, blockHash common.Hash, isForPreFetch bool) (eth.BlockInfo, types.Receipts, error, bool) {
-	info, txs, err := s.InfoAndTxsByHash(ctx, blockHash)
+	info, txs, err := s.infoAndTxsByHash(ctx, blockHash, !isForPreFetch)
 	if err != nil {
 		return nil, nil, err, false
 	}
@@ -376,7 +380,7 @@ func (s *EthClient) fetchReceiptsInner(ctx context.Context, blockHash common.Has
 	// The underlying fetcher uses the receipts hash to verify receipt integrity.
 	var job *receiptsFetchingJob
 	var isFull bool
-	v, ok := s.receiptsCache.Get(info.NumberU64())
+	v, ok := s.receiptsCache.Get(info.NumberU64(), !isForPreFetch)
 	if ok && v.blockHash == blockHash {
 		job = v.job
 	} else {

--- a/op-node/sources/eth_client_test.go
+++ b/op-node/sources/eth_client_test.go
@@ -110,7 +110,7 @@ func TestEthClient_InfoByHash(t *testing.T) {
 		"eth_getBlockByHash", []any{rhdr.Hash, false}).Run(func(args mock.Arguments) {
 		*args[1].(**rpcHeader) = rhdr
 	}).Return([]error{nil})
-	s, err := NewEthClient(m, nil, nil, testEthClientConfig)
+	s, err := NewEthClient(m, nil, nil, testEthClientConfig, false)
 	require.NoError(t, err)
 	info, err := s.InfoByHash(ctx, rhdr.Hash)
 	require.NoError(t, err)

--- a/op-node/sources/l1_client.go
+++ b/op-node/sources/l1_client.go
@@ -179,7 +179,7 @@ func (s *L1Client) GoOrUpdatePreFetchReceipts(ctx context.Context, l1Start uint6
 								case <-s.done:
 									return
 								default:
-									if _, ok := s.receiptsCache.Get(blockNumber); ok {
+									if _, ok := s.receiptsCache.Get(blockNumber, false); ok {
 										return
 									}
 									blockInfo, err := s.L1BlockRefByNumber(ctx, blockNumber)

--- a/op-node/sources/l1_client.go
+++ b/op-node/sources/l1_client.go
@@ -186,13 +186,13 @@ func (s *L1Client) GoOrUpdatePreFetchReceipts(ctx context.Context, l1Start uint6
 								case <-s.done:
 									return
 								default:
-									pair, ok := s.receiptsCache.Get(blockNumber,false)
 									blockInfo, err := s.L1BlockRefByNumber(ctx, blockNumber)
 									if err != nil {
 										s.log.Debug("failed to fetch block ref", "err", err, "blockNumber", blockNumber)
 										time.Sleep(1 * time.Second)
 										continue
 									}
+									pair, ok := s.receiptsCache.Get(blockNumber, false)
 									if ok && pair.blockHash == blockInfo.Hash {
 										blockInfoChan <- blockInfo
 										return

--- a/op-node/sources/l1_client.go
+++ b/op-node/sources/l1_client.go
@@ -70,7 +70,7 @@ type L1Client struct {
 
 // NewL1Client wraps a RPC with bindings to fetch L1 data, while logging errors, tracking metrics (optional), and caching.
 func NewL1Client(client client.RPC, log log.Logger, metrics caching.Metrics, config *L1ClientConfig) (*L1Client, error) {
-	ethClient, err := NewEthClient(client, log, metrics, &config.EthClientConfig)
+	ethClient, err := NewEthClient(client, log, metrics, &config.EthClientConfig, true)
 	if err != nil {
 		return nil, err
 	}

--- a/op-node/sources/l1_client.go
+++ b/op-node/sources/l1_client.go
@@ -214,6 +214,7 @@ func (s *L1Client) GoOrUpdatePreFetchReceipts(ctx context.Context, l1Start uint6
 }
 
 func (s *L1Client) ClearReceiptsCacheBefore(blockNumber uint64) {
+	s.log.Debug("clear receipts cache before", "blockNumber", blockNumber)
 	s.receiptsCache.RemoveLessThan(blockNumber)
 }
 

--- a/op-node/sources/l1_client_test.go
+++ b/op-node/sources/l1_client_test.go
@@ -158,10 +158,10 @@ func TestGoOrUpdatePreFetchReceipts(t *testing.T) {
 		err2 := s.GoOrUpdatePreFetchReceipts(ctx, 81)
 		require.NoError(t, err2)
 		time.Sleep(1 * time.Second)
-		pair, ok := s.receiptsCache.Get(100)
+		pair, ok := s.receiptsCache.Get(100, false)
 		require.True(t, ok, "100 cache miss")
 		require.Equal(t, real100Hash, pair.blockHash, "block 100 hash is different,want:%s,but:%s", real100Hash, pair.blockHash)
-		_, ok2 := s.receiptsCache.Get(76)
+		_, ok2 := s.receiptsCache.Get(76, false)
 		require.True(t, ok2, "76 cache miss")
 	})
 }

--- a/op-node/sources/l2_client.go
+++ b/op-node/sources/l2_client.go
@@ -78,7 +78,7 @@ type L2Client struct {
 // for fetching and caching eth.L2BlockRef values. This includes fetching an L2BlockRef by block number, label, or hash.
 // See: [L2BlockRefByLabel], [L2BlockRefByNumber], [L2BlockRefByHash]
 func NewL2Client(client client.RPC, log log.Logger, metrics caching.Metrics, config *L2ClientConfig) (*L2Client, error) {
-	ethClient, err := NewEthClient(client, log, metrics, &config.EthClientConfig)
+	ethClient, err := NewEthClient(client, log, metrics, &config.EthClientConfig, false)
 	if err != nil {
 		return nil, err
 	}

--- a/op-node/sources/receipts_test.go
+++ b/op-node/sources/receipts_test.go
@@ -162,7 +162,7 @@ func (tc *ReceiptsTestCase) Run(t *testing.T) {
 		testCfg.MethodResetDuration = 0
 	}
 	logger := testlog.Logger(t, log.LvlError)
-	ethCl, err := NewEthClient(client.NewBaseRPCClient(cl), logger, nil, testCfg)
+	ethCl, err := NewEthClient(client.NewBaseRPCClient(cl), logger, nil, testCfg, true)
 	require.NoError(t, err)
 	defer ethCl.Close()
 

--- a/ops-bedrock/Dockerfile.l1
+++ b/ops-bedrock/Dockerfile.l1
@@ -4,8 +4,6 @@ RUN git clone https://github.com/bnb-chain/bsc.git
 RUN cd bsc && git checkout v1.2.12 && make geth && go build -o ./build/bin/bootnode ./cmd/bootnode
 RUN git clone https://github.com/bnb-chain/node.git
 RUN cd node && git checkout v0.10.16 && make build
-RUN git clone https://github.com/bnb-chain/test-crosschain-transfer.git
-RUN cd test-crosschain-transfer && go build
 
 FROM golang:1.19-alpine3.18
 
@@ -18,6 +16,5 @@ COPY --from=build /go/bsc/build/bin/geth /db/node-deploy/bin/geth
 COPY --from=build /go/bsc/build/bin/bootnode /db/node-deploy/bin/bootnode
 COPY --from=build /go/node/build/tbnbcli /db/node-deploy/bin/tbnbcli
 COPY --from=build /go/node/build/bnbchaind /db/node-deploy/bin/bnbchaind
-COPY --from=build /go/test-crosschain-transfer/test-crosschain-transfer /db/node-deploy/bin/test-crosschain-transfer
 
 ENTRYPOINT ["/bin/sh", "/l1-entrypoint.sh"]

--- a/ops-bedrock/Dockerfile.l2
+++ b/ops-bedrock/Dockerfile.l2
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 ghcr.io/bnb-chain/op-geth:latest
+FROM --platform=linux/amd64 ghcr.io/bnb-chain/op-geth:develop
 
 RUN apk add --no-cache jq
 


### PR DESCRIPTION
### Description

In https://github.com/bnb-chain/opbnb/pull/100 and https://github.com/bnb-chain/opbnb/pull/104, I modified the pre-fetch logic for receipts. Based on metrics, we found that the performance of the block info and transaction retrieval APIs is also poor when L1 load is high. We need to fetch this data in advance and put it into cache. As the `InfoAndTxsByHash` is called in the `FetchReceipts` interface, the pre-fetch logic for block info and transaction data has already been performed in the receipts. I just need to make some modifications to the existing unreasonable parts to make pre-fetch effective for block info and transactions.


### Rationale

LRU cache is not applicable in all cases, so I added the bool parameter `isReadOrderly` to EthClient. When we request L1 from our EthClient, we request the data in order of block height, so `isReadOrderly` should be true. When we request L2 from our EthClient, we do not request in order of block height, so `isReadOrderly` should be false. When `isReadOrderly` is true, the LRU cache should not insert the most recently accessed block at the front of the queue, causing the data in the queue to not be sorted in order of block height(When the LRU cache is full, the queue sorted in block height order can help us eliminate old and no longer needed block heights). Therefore, I use Peek instead of Get method to avoid this situation.

### Example

none

### Changes

Notable changes:
1. LRU cache is not applicable in all cases, so I added the bool parameter `isReadOrderly` to EthClient. When `isReadOrderly` is true, I use Peek instead of Get method in LRU cache.
2. During pre-fetching, I do not track metrics, so our metrics panel can show the true hit rate.
3. There are currently some issues with the devnet running, as BSC has deleted the test-crosschain-transfer repository, which we actually did not use. Therefore, I have removed it from the dockerfile. At the same time, we have switched to using the develop branch of geth, so that we can use the latest code for testing.
