### PR TITLE
fix(op-node): remove 3s stepCtx for sequencer

### DIFF
--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -369,13 +369,7 @@ func (s *Driver) eventLoop() {
 		case <-stepReqCh:
 			s.metrics.SetDerivationIdle(false)
 			s.log.Debug("Derivation process step", "onto_origin", s.derivation.Origin(), "attempts", stepAttempts)
-			stepCtx := context.Background()
-			if s.driverConfig.SequencerEnabled && !s.driverConfig.SequencerStopped && s.driverConfig.SequencerPriority {
-				var cancelStep context.CancelFunc
-				stepCtx, cancelStep = context.WithTimeout(ctx, 3*time.Second)
-				defer cancelStep()
-			}
-			err := s.derivation.Step(stepCtx)
+			err := s.derivation.Step(context.Background())
 			stepAttempts += 1 // count as attempt by default. We reset to 0 if we are making healthy progress.
 			if err == io.EOF {
 				s.log.Debug("Derivation process went idle", "progress", s.derivation.Origin(), "err", err)


### PR DESCRIPTION
### Description

remove 3s timeout context for sequencer in case stepReqCh

### Rationale

for 200M block gas limit, full block could has 9k+ txns and call eth_getBlockByHash to get a fullblock would timeout if we limited timeout context to 3s, which especially would happen when resetting pipeline
### Example
n/a

### Changes
remove 3s timeout context for sequencer in case stepReqCh in state.go

