### PR TITLE
fix(op-node/op-batcher/op-proposer): the fallback client should always try recover

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+#          go-version-file: go.mod
+          go-version: '1.20.13'
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: '1.20.13'
 
       - name: Install gotestsum
         uses: autero1/action-gotestsum@v2.0.0
@@ -104,7 +104,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: '1.20.13'
 
       - name: Install gotestsum
         uses: autero1/action-gotestsum@v2.0.0
@@ -133,7 +133,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: '1.20.13'
 
       - name: Install gotestsum
         uses: autero1/action-gotestsum@v2.0.0
@@ -162,7 +162,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: '1.20.13'
 
       - name: Install gotestsum
         uses: autero1/action-gotestsum@v2.0.0
@@ -193,7 +193,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: '1.20.13'
 
       - name: Install gotestsum
         uses: autero1/action-gotestsum@v2.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
           go-version-file: go.mod
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
           working-directory: op-node
-          version: latest
+          version: v1.55.2
           args: -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 5m -e "errors.As" -e "errors.Is"
 
   op-batcher-lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-#          go-version-file: go.mod
           go-version: '1.20.13'
 
       - name: golangci-lint
@@ -35,15 +34,15 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: '1.20.13'
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
           working-directory: op-batcher
-          version: latest
+          version: v1.55.2
           args: -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 5m -e "errors.As" -e "errors.Is"
 
   op-proposer-lint:
@@ -54,15 +53,15 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: '1.20.13'
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
           working-directory: op-proposer
-          version: latest
+          version: v1.55.2
           args: -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 5m -e "errors.As" -e "errors.Is"
 
   op-node-test:
@@ -74,7 +73,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
@@ -103,7 +102,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
@@ -132,7 +131,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
@@ -161,7 +160,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
@@ -192,7 +191,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 

--- a/op-e2e/actions/fallback_client_test.go
+++ b/op-e2e/actions/fallback_client_test.go
@@ -1,6 +1,10 @@
 package actions
 
 import (
+	"math/big"
+	"testing"
+	"time"
+
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
 	"github.com/ethereum-optimism/optimism/op-node/client"
 	"github.com/ethereum-optimism/optimism/op-node/eth"
@@ -12,9 +16,6 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/require"
-	"math/big"
-	"testing"
-	"time"
 )
 
 func setupFallbackClientTest(t Testing, sd *e2eutils.SetupData, log log.Logger, l1Url string) (*L1Miner, *L1Replica, *L1Replica, *L2Engine, *L2Sequencer, *sources.FallbackClient) {

--- a/op-node/sources/fallback_client.go
+++ b/op-node/sources/fallback_client.go
@@ -157,6 +157,7 @@ func (l *FallbackClient) switchCurrentRpc() {
 }
 
 func (l *FallbackClient) switchCurrentRpcLogic() error {
+	//Use defer to ensure that recoverIfFirstRpcHealth will always be executed regardless of the circumstances.
 	defer func() {
 		if !l.isInFallbackState {
 			l.isInFallbackState = true

--- a/op-node/sources/fallback_client.go
+++ b/op-node/sources/fallback_client.go
@@ -157,6 +157,12 @@ func (l *FallbackClient) switchCurrentRpc() {
 }
 
 func (l *FallbackClient) switchCurrentRpcLogic() error {
+	defer func() {
+		if !l.isInFallbackState {
+			l.isInFallbackState = true
+			l.recoverIfFirstRpcHealth()
+		}
+	}()
 	url := l.urlList[l.currentIndex]
 	newRpc, err := l.rpcInitFunc(url)
 	if err != nil {
@@ -179,10 +185,6 @@ func (l *FallbackClient) switchCurrentRpcLogic() error {
 		}
 	}
 	l.log.Info("switched current rpc to new url", "url", url)
-	if !l.isInFallbackState {
-		l.isInFallbackState = true
-		l.recoverIfFirstRpcHealth()
-	}
 	return nil
 }
 

--- a/op-node/sources/fallback_client.go
+++ b/op-node/sources/fallback_client.go
@@ -223,7 +223,9 @@ func (l *FallbackClient) recoverIfFirstRpcHealth() {
 		}
 		lastRpc := *l.currentRpc.Load()
 		l.currentRpc.Store(&l.firstRpc)
-		lastRpc.Close()
+		if lastRpc != l.firstRpc {
+			lastRpc.Close()
+		}
 		l.lastMinuteFail.Store(0)
 		l.currentIndex = 0
 		l.isInFallbackState = false

--- a/op-service/client/fallback_client.go
+++ b/op-service/client/fallback_client.go
@@ -240,6 +240,7 @@ func (l *FallbackClient) switchCurrentClient() {
 	if l.lastMinuteFail.Load() <= l.fallbackThreshold {
 		return
 	}
+	//Use defer to ensure that recoverIfFirstRpcHealth will always be executed regardless of the circumstances.
 	defer func() {
 		if !l.isInFallbackState {
 			l.isInFallbackState = true

--- a/op-service/client/fallback_client.go
+++ b/op-service/client/fallback_client.go
@@ -240,6 +240,12 @@ func (l *FallbackClient) switchCurrentClient() {
 	if l.lastMinuteFail.Load() <= l.fallbackThreshold {
 		return
 	}
+	defer func() {
+		if !l.isInFallbackState {
+			l.isInFallbackState = true
+			l.recoverIfFirstRpcHealth()
+		}
+	}()
 	l.currentIndex++
 	if l.currentIndex >= len(l.urlList) {
 		l.log.Error("the fallback client has tried all urls")
@@ -259,10 +265,6 @@ func (l *FallbackClient) switchCurrentClient() {
 	}
 	l.lastMinuteFail.Store(0)
 	l.log.Info("switched current rpc to new url", "url", url)
-	if !l.isInFallbackState {
-		l.isInFallbackState = true
-		l.recoverIfFirstRpcHealth()
-	}
 }
 
 func (l *FallbackClient) recoverIfFirstRpcHealth() {
@@ -287,7 +289,9 @@ func (l *FallbackClient) recoverIfFirstRpcHealth() {
 		}
 		lastClient := *l.currentClient.Load()
 		l.currentClient.Store(&l.firstClient)
-		lastClient.Close()
+		if lastClient != l.firstClient {
+			lastClient.Close()
+		}
 		l.lastMinuteFail.Store(0)
 		l.currentIndex = 0
 		l.isInFallbackState = false


### PR DESCRIPTION
### Description

In extreme cases, all of our endpoint URLs may be unable to connect, and the `rpcInitFunc` will return an error, causing the `recoverIfFirstRpcHealth` function to not have a chance to execute. So when the endpoint URLs are restored, our currentIndex counter still points to the end of the urlList array, causing internal state confusion in the fallbackClient and permanently disabling the fallback function until the node is restarted.

### Rationale

We use `defer` to ensure that no matter what the situation, `recoverIfFirstRpcHealth` will be executed.

### Example

none

### Changes

Notable changes:
* Use `defer` to ensure that `recoverIfFirstRpcHealth` will always be executed regardless of the circumstances.
* Add a judgment condition to avoid mistakenly closing firstRpc with `lastRpc.Close()`, which will cause confusion in subsequent logic execution.
