### PR TITLE
feat(op-node): pre-fetch block info and transaction

### DIFF
--- a/op-service/sources/caching/cache.go
+++ b/op-service/sources/caching/cache.go
@@ -22,13 +22,13 @@ func (c *LRUCache[K, V]) Get(key K) (value V, ok bool) {
 	return value, ok
 }
 
-func (c *LRUCache[K,V]) GetOrPeek(key K, usePeek bool) (value V, ok bool) {
+func (c *LRUCache[K,V]) GetOrPeek(key K, usePeek bool, recordMetrics bool) (value V, ok bool) {
 	if usePeek {
 		value, ok = c.inner.Peek(key)
 	} else {
 		value, ok = c.inner.Get(key)
 	}
-	if c.m != nil {
+	if c.m != nil && recordMetrics {
 		c.m.CacheGet(c.label, ok)
 	}
 	return value, ok

--- a/op-service/sources/caching/cache.go
+++ b/op-service/sources/caching/cache.go
@@ -22,6 +22,18 @@ func (c *LRUCache[K, V]) Get(key K) (value V, ok bool) {
 	return value, ok
 }
 
+func (c *LRUCache[K,V]) GetOrPeek(key K, usePeek bool) (value V, ok bool) {
+	if usePeek {
+		value, ok = c.inner.Peek(key)
+	} else {
+		value, ok = c.inner.Get(key)
+	}
+	if c.m != nil {
+		c.m.CacheGet(c.label, ok)
+	}
+	return value, ok
+}
+
 func (c *LRUCache[K, V]) Add(key K, value V) (evicted bool) {
 	evicted = c.inner.Add(key, value)
 	if c.m != nil {

--- a/op-service/sources/caching/pre_fetch_cache.go
+++ b/op-service/sources/caching/pre_fetch_cache.go
@@ -57,11 +57,11 @@ func (v *PreFetchCache[V]) AddIfNotFull(key uint64, value V) (success bool, isFu
 	return true, false
 }
 
-func (v *PreFetchCache[V]) Get(key uint64) (V, bool) {
+func (v *PreFetchCache[V]) Get(key uint64, recordMetrics bool) (V, bool) {
 	defer v.lock.Unlock()
 	v.lock.Lock()
 	value, ok := v.inner[key]
-	if v.m != nil {
+	if v.m != nil && recordMetrics {
 		v.m.CacheGet(v.label, ok)
 	}
 	return value, ok

--- a/op-service/sources/eth_client_test.go
+++ b/op-service/sources/eth_client_test.go
@@ -110,7 +110,7 @@ func TestEthClient_InfoByHash(t *testing.T) {
 		"eth_getBlockByHash", []any{rhdr.Hash, false}).Run(func(args mock.Arguments) {
 		*args[1].(**rpcHeader) = rhdr
 	}).Return([]error{nil})
-	s, err := NewEthClient(m, nil, nil, testEthClientConfig)
+	s, err := NewEthClient(m, nil, nil, testEthClientConfig, false)
 	require.NoError(t, err)
 	info, err := s.InfoByHash(ctx, rhdr.Hash)
 	require.NoError(t, err)

--- a/op-service/sources/l1_client.go
+++ b/op-service/sources/l1_client.go
@@ -251,6 +251,7 @@ func (s *L1Client) GoOrUpdatePreFetchReceipts(ctx context.Context, l1Start uint6
 }
 
 func (s *L1Client) ClearReceiptsCacheBefore(blockNumber uint64) {
+	s.log.Debug("clear receipts cache before", "blockNumber", blockNumber)
 	s.receiptsCache.RemoveLessThan(blockNumber)
 }
 

--- a/op-service/sources/l1_client.go
+++ b/op-service/sources/l1_client.go
@@ -187,13 +187,13 @@ func (s *L1Client) GoOrUpdatePreFetchReceipts(ctx context.Context, l1Start uint6
 								case <-s.done:
 									return
 								default:
-									pair, ok := s.receiptsCache.Get(blockNumber,false)
 									blockInfo, err := s.L1BlockRefByNumber(ctx, blockNumber)
 									if err != nil {
 										s.log.Debug("failed to fetch block ref", "err", err, "blockNumber", blockNumber)
 										time.Sleep(1 * time.Second)
 										continue
 									}
+									pair, ok := s.receiptsCache.Get(blockNumber, false)
 									if ok && pair.blockHash == blockInfo.Hash {
 										blockInfoChan <- blockInfo
 										return

--- a/op-service/sources/l1_client.go
+++ b/op-service/sources/l1_client.go
@@ -73,7 +73,7 @@ type L1Client struct {
 
 // NewL1Client wraps a RPC with bindings to fetch L1 data, while logging errors, tracking metrics (optional), and caching.
 func NewL1Client(client client.RPC, log log.Logger, metrics caching.Metrics, config *L1ClientConfig) (*L1Client, error) {
-	ethClient, err := NewEthClient(client, log, metrics, &config.EthClientConfig)
+	ethClient, err := NewEthClient(client, log, metrics, &config.EthClientConfig, true)
 	if err != nil {
 		return nil, err
 	}

--- a/op-service/sources/l1_client.go
+++ b/op-service/sources/l1_client.go
@@ -187,7 +187,7 @@ func (s *L1Client) GoOrUpdatePreFetchReceipts(ctx context.Context, l1Start uint6
 								case <-s.done:
 									return
 								default:
-									pair, ok := s.receiptsCache.Get(blockNumber)
+									pair, ok := s.receiptsCache.Get(blockNumber,false)
 									blockInfo, err := s.L1BlockRefByNumber(ctx, blockNumber)
 									if err != nil {
 										s.log.Debug("failed to fetch block ref", "err", err, "blockNumber", blockNumber)

--- a/op-service/sources/l1_client_test.go
+++ b/op-service/sources/l1_client_test.go
@@ -158,10 +158,10 @@ func TestGoOrUpdatePreFetchReceipts(t *testing.T) {
 		err2 := s.GoOrUpdatePreFetchReceipts(ctx, 81)
 		require.NoError(t, err2)
 		time.Sleep(1 * time.Second)
-		pair, ok := s.receiptsCache.Get(100)
+		pair, ok := s.receiptsCache.Get(100, false)
 		require.True(t, ok, "100 cache miss")
 		require.Equal(t, real100Hash, pair.blockHash, "block 100 hash is different,want:%s,but:%s", real100Hash, pair.blockHash)
-		_, ok2 := s.receiptsCache.Get(76)
+		_, ok2 := s.receiptsCache.Get(76, false)
 		require.True(t, ok2, "76 cache miss")
 	})
 }

--- a/op-service/sources/l2_client.go
+++ b/op-service/sources/l2_client.go
@@ -79,7 +79,7 @@ type L2Client struct {
 // for fetching and caching eth.L2BlockRef values. This includes fetching an L2BlockRef by block number, label, or hash.
 // See: [L2BlockRefByLabel], [L2BlockRefByNumber], [L2BlockRefByHash]
 func NewL2Client(client client.RPC, log log.Logger, metrics caching.Metrics, config *L2ClientConfig) (*L2Client, error) {
-	ethClient, err := NewEthClient(client, log, metrics, &config.EthClientConfig)
+	ethClient, err := NewEthClient(client, log, metrics, &config.EthClientConfig, false)
 	if err != nil {
 		return nil, err
 	}

--- a/op-service/sources/receipts_test.go
+++ b/op-service/sources/receipts_test.go
@@ -162,7 +162,7 @@ func (tc *ReceiptsTestCase) Run(t *testing.T) {
 		testCfg.MethodResetDuration = 0
 	}
 	logger := testlog.Logger(t, log.LvlError)
-	ethCl, err := NewEthClient(client.NewBaseRPCClient(cl), logger, nil, testCfg)
+	ethCl, err := NewEthClient(client.NewBaseRPCClient(cl), logger, nil, testCfg, true)
 	require.NoError(t, err)
 	defer ethCl.Close()
 

--- a/ops-bedrock/Dockerfile.l2
+++ b/ops-bedrock/Dockerfile.l2
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 ghcr.io/bnb-chain/op-geth:latest
+FROM --platform=linux/amd64 ghcr.io/bnb-chain/op-geth:develop
 
 RUN apk add --no-cache jq
 


### PR DESCRIPTION
### Description

In https://github.com/bnb-chain/opbnb/pull/100 and https://github.com/bnb-chain/opbnb/pull/104, I modified the pre-fetch logic for receipts. Based on metrics, we found that the performance of the block info and transaction retrieval APIs is also poor when L1 load is high. We need to fetch this data in advance and put it into cache. As the InfoAndTxsByHash is called in the FetchReceipts interface, the pre-fetch logic for block info and transaction data has already been performed in the receipts. I just need to make some modifications to the existing unreasonable parts to make pre-fetch effective for block info and transactions.

### Rationale

LRU cache is not applicable in all cases, so I added the bool parameter isReadOrderly to EthClient. When we request L1 from our EthClient, we request the data in order of block height, so isReadOrderly should be true. When we request L2 from our EthClient, we do not request in order of block height, so isReadOrderly should be false. When isReadOrderly is true, the LRU cache should not insert the most recently accessed block at the front of the queue, causing the data in the queue to not be sorted in order of block height(When the LRU cache is full, the queue sorted in block height order can help us eliminate old and no longer needed block heights). Therefore, I use Peek instead of Get method to avoid this situation.

### Example

none

### Changes

Notable changes:
1. LRU cache is not applicable in all cases, so I added the bool parameter `isReadOrderly` to EthClient. When `isReadOrderly` is true, I use Peek instead of Get method in LRU cache.
2. During pre-fetching, I do not track metrics, so our metrics panel can show the true hit rate.
3. There are currently some issues with the devnet running, as BSC has deleted the test-crosschain-transfer repository, which we actually did not use. Therefore, I have removed it from the dockerfile. At the same time, we have switched to using the develop branch of geth, so that we can use the latest code for testing.
