### PR TITLE
chore: add bootnode to docker-release.yml workflow

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -108,3 +108,36 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  push-op-bootnode:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: image meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ github.repository_owner }}/op-bootnode
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=sha
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./op-bootnode/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/op-bootnode/Dockerfile
+++ b/op-bootnode/Dockerfile
@@ -1,0 +1,35 @@
+FROM --platform=$BUILDPLATFORM golang:1.21.5-alpine3.18 as builder
+
+ARG VERSION=v0.0.0
+
+RUN apk add --no-cache build-base libc-dev
+RUN apk add --no-cache make gcc musl-dev linux-headers git jq bash
+
+# build op-bootnode with the shared go.mod & go.sum files
+COPY ./op-bootnode /app/op-bootnode
+COPY ./op-bindings /app/op-bindings
+COPY ./op-node /app/op-node
+COPY ./op-service /app/op-service
+COPY ./op-aws-sdk /app/op-aws-sdk
+COPY ./go.mod /app/go.mod
+COPY ./go.sum /app/go.sum
+
+COPY ./.git /app/.git
+
+WORKDIR /app/op-bootnode
+
+RUN go mod download
+
+ARG TARGETOS TARGETARCH
+
+ENV CGO_CFLAGS="-O -D__BLST_PORTABLE__"
+ENV CGO_CFLAGS_ALLOW="-O -D__BLST_PORTABLE__"
+RUN make op-bootnode VERSION="$VERSION" GOOS=$TARGETOS GOARCH=$TARGETARCH
+
+FROM alpine:3.18
+
+RUN apk add --no-cache libstdc++
+
+COPY --from=builder /app/op-bootnode/bin/op-bootnode /usr/local/bin
+
+ENTRYPOINT ["op-bootnode"]


### PR DESCRIPTION
### Description

 add bootnode to docker-release.yml workflow
### Rationale

bootnode package release is missed
### Example

n/a
### Changes

Notable changes:
1.  add bootnode to docker-release.yml workflow
