### PR TITLE
feat: optimize l1 gas price calculation after snow hardfork

### DIFF
--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -735,6 +735,7 @@ func NewL2StorageConfig(config *DeployConfig, block *types.Block) (state.Storage
 	//}
 
 	var baseFee *big.Int
+	// Simplify the basefee when constructing the genesis block and ignore the Snow fork logic just in genesis.
 	if config.Fermat != nil && config.Fermat.Cmp(big.NewInt(0)) <= 0 {
 		baseFee = bsc.BaseFeeByNetworks(big.NewInt(int64(config.L2ChainID)))
 	} else {

--- a/op-node/chaincfg/chains.go
+++ b/op-node/chaincfg/chains.go
@@ -85,13 +85,13 @@ func GetRollupConfig(name string) (*rollup.Config, error) {
 var NetworksByName = map[string]rollup.Config{
 	"opBNBMainnet": OPBNBMainnet,
 	"opBNBTestnet": OPBNBTestnet,
-	"opBNBDevnet":  OPBNBDevnet,
+	"opBNBQANet":   OPBNBQANet,
 }
 
 var NetworksByChainId = map[string]rollup.Config{
 	"204":  OPBNBMainnet,
 	"5611": OPBNBTestnet,
-	"1320": OPBNBDevnet,
+	"1322": OPBNBQANet,
 }
 
 func GetRollupConfigByNetwork(name string) (rollup.Config, error) {
@@ -141,6 +141,8 @@ var OPBNBMainnet = rollup.Config{
 	L1SystemConfigAddress:  common.HexToAddress("0x7ac836148c14c74086d57f7828f2d065672db3b8"),
 	RegolithTime:           u64Ptr(0),
 	Fermat:                 big.NewInt(9397477), // Nov-28-2023 06 AM +UTC
+	// TODO update block number
+	Snow: nil,
 }
 
 var OPBNBTestnet = rollup.Config{
@@ -172,21 +174,23 @@ var OPBNBTestnet = rollup.Config{
 	L1SystemConfigAddress:  common.HexToAddress("0x406ac857817708eaf4ca3a82317ef4ae3d1ea23b"),
 	RegolithTime:           u64Ptr(0),
 	Fermat:                 big.NewInt(12113000), // Nov-03-2023 06 AM +UTC
+	// TODO update block number
+	Snow: nil,
 }
 
-var OPBNBDevnet = rollup.Config{
+var OPBNBQANet = rollup.Config{
 	Genesis: rollup.Genesis{
 		L1: eth.BlockID{
-			Hash:   common.HexToHash("0x29aee50ab3edefa64219e5c9b9c07f7d1953a98f2f4003d2c6fd93abeee4b706"),
-			Number: 2890195,
+			Hash:   common.HexToHash("0x3db93722c9951fe1da25dd652c6e2367674a97161df2acea322e915cab0d58ba"),
+			Number: 742038,
 		},
 		L2: eth.BlockID{
-			Hash:   common.HexToHash("0x49d448b8dc98cc95e3968615ff3dbd904d9eec8252c5f52271f029896e6147ee"),
+			Hash:   common.HexToHash("0x1cba296441b55cf9b5b306b6aef43e68e9aeff2450d68c391dec448604cf3baf"),
 			Number: 0,
 		},
-		L2Time: 1694166483,
+		L2Time: 1704856150,
 		SystemConfig: eth.SystemConfig{
-			BatcherAddr: common.HexToAddress("0x425a3598cb5e2d37213936e187914ea2059957ba"),
+			BatcherAddr: common.HexToAddress("0xe309831c77d5fb5f189dd97c598e26e5c014f2d6"),
 			Overhead:    eth.Bytes32(common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000834")),
 			Scalar:      eth.Bytes32(common.HexToHash("0x00000000000000000000000000000000000000000000000000000000000f4240")),
 			GasLimit:    100000000,
@@ -196,13 +200,15 @@ var OPBNBDevnet = rollup.Config{
 	MaxSequencerDrift:      600,
 	SeqWindowSize:          14400,
 	ChannelTimeout:         1200,
-	L1ChainID:              big.NewInt(797),
-	L2ChainID:              big.NewInt(1320),
-	BatchInboxAddress:      common.HexToAddress("0xff00000000000000000000000000000000000204"),
-	DepositContractAddress: common.HexToAddress("0xd93160096c5b65bb036b3269eb02328ddadb9856"),
-	L1SystemConfigAddress:  common.HexToAddress("0xf053067cec8d8990de2ba9e17ec2f16c63c7bec4"),
+	L1ChainID:              big.NewInt(714),
+	L2ChainID:              big.NewInt(1322),
+	BatchInboxAddress:      common.HexToAddress("0xff00000000000000000000000000000000001322"),
+	DepositContractAddress: common.HexToAddress("0xb7cdbce0b1f153b4cb2acc36aeb4d9d2cdda1132"),
+	L1SystemConfigAddress:  common.HexToAddress("0x6a2607255801095b23256a341b24d31275fe2438"),
 	RegolithTime:           u64Ptr(0),
-	Fermat:                 big.NewInt(3615117),
+	// Fermat:                 big.NewInt(3615117),
+	// TODO update block number
+	Snow: nil,
 }
 
 func u64Ptr(v uint64) *uint64 {

--- a/op-node/chaincfg/chains.go
+++ b/op-node/chaincfg/chains.go
@@ -141,8 +141,8 @@ var OPBNBMainnet = rollup.Config{
 	L1SystemConfigAddress:  common.HexToAddress("0x7ac836148c14c74086d57f7828f2d065672db3b8"),
 	RegolithTime:           u64Ptr(0),
 	Fermat:                 big.NewInt(9397477), // Nov-28-2023 06 AM +UTC
-	// TODO update block number
-	Snow: nil,
+	// TODO update timestamp
+	SnowTime: nil,
 }
 
 var OPBNBTestnet = rollup.Config{
@@ -174,8 +174,8 @@ var OPBNBTestnet = rollup.Config{
 	L1SystemConfigAddress:  common.HexToAddress("0x406ac857817708eaf4ca3a82317ef4ae3d1ea23b"),
 	RegolithTime:           u64Ptr(0),
 	Fermat:                 big.NewInt(12113000), // Nov-03-2023 06 AM +UTC
-	// TODO update block number
-	Snow: nil,
+	// TODO update timestamp
+	SnowTime: nil,
 }
 
 var OPBNBQANet = rollup.Config{
@@ -206,9 +206,9 @@ var OPBNBQANet = rollup.Config{
 	DepositContractAddress: common.HexToAddress("0xb7cdbce0b1f153b4cb2acc36aeb4d9d2cdda1132"),
 	L1SystemConfigAddress:  common.HexToAddress("0x6a2607255801095b23256a341b24d31275fe2438"),
 	RegolithTime:           u64Ptr(0),
-	// Fermat:                 big.NewInt(3615117),
-	// TODO update block number
-	Snow: nil,
+	// Fermat:              big.NewInt(3615117),
+	// TODO update timestamp
+	SnowTime: nil,
 }
 
 func u64Ptr(v uint64) *uint64 {

--- a/op-node/rollup/derive/attributes.go
+++ b/op-node/rollup/derive/attributes.go
@@ -161,7 +161,7 @@ func (ba *FetchingAttributesBuilder) CachePayloadByHash(payload *eth.ExecutionPa
 
 func SnowL1GasPrice(ctx context.Context, ba *FetchingAttributesBuilder, epoch eth.BlockID) (*big.Int, error) {
 	// Consider this situation. If start a new l2 chain, starting from the block height of l1 less than CountBlockSize,
-	// in fact, this situation is unlikely to happen.
+	// in fact, this situation is unlikely to happen except some test cases.
 	if epoch.Number < bsc.CountBlockSize-1 {
 		return bsc.DefaultBaseFee, nil
 	}

--- a/op-node/rollup/derive/attributes.go
+++ b/op-node/rollup/derive/attributes.go
@@ -179,7 +179,7 @@ func calculateL1GasPrice(ctx context.Context, ba *FetchingAttributesBuilder, epo
 			medianGasPriceQueue.Init()
 		}
 	} else {
-		if latestBlockNumber < epoch.Number {
+		if latestBlockNumber > epoch.Number {
 			// L2 or L1 reorg, clear medianGasPriceQueue
 			medianGasPriceQueue.Init()
 		}

--- a/op-node/rollup/derive/attributes.go
+++ b/op-node/rollup/derive/attributes.go
@@ -165,6 +165,7 @@ func calculateL1GasPrice(ctx context.Context, ba *FetchingAttributesBuilder, epo
 			medianGasPriceQueue.PushBack(bsc.DefaultBaseFee)
 		}
 	}
+	// TODO handle L1 reorg / L2 reorg / L1 derive multi L2 blocks
 	block, transactions, err := ba.l1.InfoAndTxsByHash(ctx, epoch.Hash)
 	if err != nil {
 		return nil, NewTemporaryError(fmt.Errorf("failed to fetch L1 block info and txs: %w", err))

--- a/op-node/rollup/driver/metered_l1fetcher.go
+++ b/op-node/rollup/driver/metered_l1fetcher.go
@@ -81,8 +81,3 @@ func (m *MeteredL1Fetcher) ClearReceiptsCacheBefore(blockNumber uint64) {
 	defer m.recordTime("ClearReceiptsCacheBefore")()
 	m.inner.ClearReceiptsCacheBefore(blockNumber)
 }
-
-func (m *MeteredL1Fetcher) InfoAndTxsByNumber(ctx context.Context, num uint64) (eth.BlockInfo, types.Transactions, error) {
-	defer m.recordTime("InfoAndTxsByNumber")()
-	return m.inner.InfoAndTxsByNumber(ctx, num)
-}

--- a/op-node/rollup/driver/metered_l1fetcher.go
+++ b/op-node/rollup/driver/metered_l1fetcher.go
@@ -81,3 +81,8 @@ func (m *MeteredL1Fetcher) ClearReceiptsCacheBefore(blockNumber uint64) {
 	defer m.recordTime("ClearReceiptsCacheBefore")()
 	m.inner.ClearReceiptsCacheBefore(blockNumber)
 }
+
+func (m *MeteredL1Fetcher) InfoAndTxsByNumber(ctx context.Context, num uint64) (eth.BlockInfo, types.Transactions, error) {
+	defer m.recordTime("InfoAndTxsByNumber")()
+	return m.inner.InfoAndTxsByNumber(ctx, num)
+}

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -7,12 +7,10 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/params"
-
-	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
 var (
@@ -329,18 +327,16 @@ func isTimestampForked(s *uint64, head uint64) bool {
 func (c *Config) Description(l2Chains map[string]string) string {
 	// Find and report the network the user is running
 	var banner string
-	networkL2 := ""
+	// replace using opBNB networks
+	networkL2 := NetworkNames[c.L2ChainID.String()]
 	if l2Chains != nil {
 		networkL2 = l2Chains[c.L2ChainID.String()]
 	}
-	// replace using opBNB networks
-	networkL2 = NetworkNames[c.L2ChainID.String()]
 	if networkL2 == "" {
 		networkL2 = "unknown L2"
 	}
-	networkL1 := params.NetworkNames[c.L1ChainID.String()]
 	// replace using bsc networks
-	networkL1 = NetworkNames[c.L1ChainID.String()]
+	networkL1 := NetworkNames[c.L1ChainID.String()]
 	if networkL1 == "" {
 		networkL1 = "unknown L1"
 	}
@@ -370,14 +366,16 @@ func (c *Config) Description(l2Chains map[string]string) string {
 // The config should be config.Check()-ed before creating a description.
 func (c *Config) LogDescription(log log.Logger, l2Chains map[string]string) {
 	// Find and report the network the user is running
-	networkL2 := ""
+	// replace using opBNB networks
+	networkL2 := NetworkNames[c.L2ChainID.String()]
 	if l2Chains != nil {
 		networkL2 = l2Chains[c.L2ChainID.String()]
 	}
 	if networkL2 == "" {
 		networkL2 = "unknown L2"
 	}
-	networkL1 := params.NetworkNames[c.L1ChainID.String()]
+	// replace using bsc networks
+	networkL1 := NetworkNames[c.L1ChainID.String()]
 	if networkL1 == "" {
 		networkL1 = "unknown L1"
 	}

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -387,7 +387,7 @@ func (c *Config) LogDescription(log log.Logger, l2Chains map[string]string) {
 		"l1_block_number", c.Genesis.L1.Number, "regolith_time", fmtForkTimeOrUnset(c.RegolithTime),
 		"canyon_time", fmtForkTimeOrUnset(c.CanyonTime),
 		"span_batch_time", fmtForkTimeOrUnset(c.SpanBatchTime),
-		"Fermat", c.Fermat, "Snow", fmtForkTimeOrUnset(c.SnowTime),
+		"fermat", c.Fermat, "snow_time", fmtForkTimeOrUnset(c.SnowTime),
 	)
 }
 

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -84,7 +84,7 @@ type Config struct {
 	// OPBNB hard fork L2 block number
 	// Fermat switch block (nil = no fork, 0 = already on Fermat)
 	Fermat *big.Int `json:"fermat,omitempty"`
-	// Snow switch block (nil = no fork, 0 = already on L1GasPriceOptimize)
+	// Snow switch block (nil = no fork, 0 = already on Snow)
 	Snow *big.Int `json:"snow,omitempty"`
 
 	// Note: below addresses are part of the block-derivation process,

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -84,6 +84,8 @@ type Config struct {
 	// OPBNB hard fork L2 block number
 	// Fermat switch block (nil = no fork, 0 = already on Fermat)
 	Fermat *big.Int `json:"fermat,omitempty"`
+	// Snow switch block (nil = no fork, 0 = already on L1GasPriceOptimize)
+	Snow *big.Int `json:"snow,omitempty"`
 
 	// Note: below addresses are part of the block-derivation process,
 	// and required to be the same network-wide to stay in consensus.
@@ -287,6 +289,11 @@ func (c *Config) IsFermat(num *big.Int) bool {
 	return isBlockForked(c.Fermat, num)
 }
 
+// IsSnow returns true if the Snow hardfork is active at or past the given block.
+func (c *Config) IsSnow(num *big.Int) bool {
+	return isBlockForked(c.Snow, num)
+}
+
 // isBlockForked returns whether a fork scheduled at block s is active at the
 // given head block. Whilst this method is the same as isTimestampForked, they
 // are explicitly separate for clearer reading.
@@ -328,6 +335,7 @@ func (c *Config) Description(l2Chains map[string]string) string {
 	banner += fmt.Sprintf("  - SpanBatch: %s\n", fmtForkTimeOrUnset(c.SpanBatchTime))
 	banner += "OPBNB hard forks (block based):\n"
 	banner += fmt.Sprintf(" - Fermat:              #%-8v\n", c.Fermat)
+	banner += fmt.Sprintf(" - Snow: #%-8v\n", c.Snow)
 	// Report the protocol version
 	banner += fmt.Sprintf("Node supports up to OP-Stack Protocol Version: %s\n", OPStackSupport)
 	return banner
@@ -355,7 +363,7 @@ func (c *Config) LogDescription(log log.Logger, l2Chains map[string]string) {
 		"l1_block_number", c.Genesis.L1.Number, "regolith_time", fmtForkTimeOrUnset(c.RegolithTime),
 		"canyon_time", fmtForkTimeOrUnset(c.CanyonTime),
 		"span_batch_time", fmtForkTimeOrUnset(c.SpanBatchTime),
-		"Fermat", c.Fermat,
+		"Fermat", c.Fermat, "Snow", c.Snow,
 	)
 }
 

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -92,8 +92,9 @@ type Config struct {
 	// OPBNB hard fork L2 block number
 	// Fermat switch block (nil = no fork, 0 = already on Fermat)
 	Fermat *big.Int `json:"fermat,omitempty"`
-	// Snow switch time (nil = no fork, 0 = already on Snow)
-	Snow *uint64 `json:"snow,omitempty"`
+	// SnowTime  sets the activation time of the next network upgrade.
+	// Active if SnowTime != nil && L2 block timestamp >= *SnowTime, inactive otherwise.
+	SnowTime *uint64 `json:"snow_time,omitempty"`
 
 	// Note: below addresses are part of the block-derivation process,
 	// and required to be the same network-wide to stay in consensus.
@@ -299,7 +300,7 @@ func (c *Config) IsFermat(num *big.Int) bool {
 
 // IsSnow returns whether the time is either equal to the Snow fork time or greater.
 func (c *Config) IsSnow(time uint64) bool {
-	return isTimestampForked(c.Snow, time)
+	return isTimestampForked(c.SnowTime, time)
 }
 
 // isBlockForked returns whether a fork scheduled at block s is active at the
@@ -358,7 +359,7 @@ func (c *Config) Description(l2Chains map[string]string) string {
 	banner += "OPBNB hard forks (block based):\n"
 	banner += fmt.Sprintf(" - Fermat:              #%-8v\n", c.Fermat)
 	banner += "OPBNB hard forks (timestamp based):\n"
-	banner += fmt.Sprintf(" - Snow: %s\n", fmtForkTimeOrUnset(c.Snow))
+	banner += fmt.Sprintf(" - Snow: %s\n", fmtForkTimeOrUnset(c.SnowTime))
 	// Report the protocol version
 	banner += fmt.Sprintf("Node supports up to OP-Stack Protocol Version: %s\n", OPStackSupport)
 	return banner
@@ -386,7 +387,7 @@ func (c *Config) LogDescription(log log.Logger, l2Chains map[string]string) {
 		"l1_block_number", c.Genesis.L1.Number, "regolith_time", fmtForkTimeOrUnset(c.RegolithTime),
 		"canyon_time", fmtForkTimeOrUnset(c.CanyonTime),
 		"span_batch_time", fmtForkTimeOrUnset(c.SpanBatchTime),
-		"Fermat", c.Fermat, "Snow", fmtForkTimeOrUnset(c.Snow),
+		"Fermat", c.Fermat, "Snow", fmtForkTimeOrUnset(c.SnowTime),
 	)
 }
 

--- a/op-node/rollup/types_test.go
+++ b/op-node/rollup/types_test.go
@@ -147,9 +147,9 @@ func TestRandomConfigDescription(t *testing.T) {
 	})
 	t.Run("named L1", func(t *testing.T) {
 		config := randConfig()
-		config.L1ChainID = big.NewInt(5)
+		config.L1ChainID = big.NewInt(97)
 		out := config.Description(map[string]string{config.L2ChainID.String(): "foobar chain"})
-		require.Contains(t, out, "goerli")
+		require.Contains(t, out, "bscTestnet")
 	})
 	t.Run("unnamed", func(t *testing.T) {
 		config := randConfig()

--- a/op-service/bsc/compat.go
+++ b/op-service/bsc/compat.go
@@ -17,10 +17,9 @@ var DefaultOPBNBTestnetBaseFee = big.NewInt(5000000000)
 var OPBNBTestnet = big.NewInt(5611)
 
 const (
-	percentile     = 50
-	CountBlockSize = 21
-	// BlockInfoCacheCap 21 validators in bsc, finalize block requires 15, 2 * (21+15) = 72 to buffer
-	BlockInfoCacheCap = 72
+	percentile        = 50
+	CountBlockSize    = 21
+	BlockInfoCacheCap = 1000
 )
 
 type BlockInfo struct {

--- a/op-service/bsc/compat.go
+++ b/op-service/bsc/compat.go
@@ -108,7 +108,6 @@ func FinalGasPrice(medianGasPriceQueue list.List) *big.Int {
 	}
 	sort.Sort(bigIntArray(allMedianGasPrice))
 	finalGasPrice := allMedianGasPrice[(len(allMedianGasPrice)-1)*percentile/100]
-	medianGasPriceQueue.Remove(medianGasPriceQueue.Front())
 	return finalGasPrice
 }
 

--- a/op-service/bsc/compat.go
+++ b/op-service/bsc/compat.go
@@ -1,7 +1,9 @@
 package bsc
 
 import (
+	"container/list"
 	"math/big"
+	"sort"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
@@ -13,6 +15,11 @@ import (
 var DefaultBaseFee = big.NewInt(3000000000)
 var DefaultOPBNBTestnetBaseFee = big.NewInt(5000000000)
 var OPBNBTestnet = big.NewInt(5611)
+
+const (
+	percentile     = 50
+	CountBlockSize = 21
+)
 
 type BlockInfoBSCWrapper struct {
 	eth.BlockInfo
@@ -78,3 +85,35 @@ func ToLegacyCallMsg(callMsg ethereum.CallMsg) ethereum.CallMsg {
 		Data:     callMsg.Data,
 	}
 }
+
+func MedianGasPrice(transactions types.Transactions) *big.Int {
+	var nonZeroTxsGasPrice []*big.Int
+	for _, tx := range transactions {
+		if tx.GasPrice().Cmp(common.Big0) > 0 {
+			nonZeroTxsGasPrice = append(nonZeroTxsGasPrice, tx.GasPrice())
+		}
+	}
+	sort.Sort(bigIntArray(nonZeroTxsGasPrice))
+	medianGasPrice := DefaultBaseFee
+	if len(nonZeroTxsGasPrice) != 0 {
+		medianGasPrice = nonZeroTxsGasPrice[(len(nonZeroTxsGasPrice)-1)*percentile/100]
+	}
+	return medianGasPrice
+}
+
+func FinalGasPrice(medianGasPriceQueue list.List) *big.Int {
+	var allMedianGasPrice []*big.Int
+	for item := medianGasPriceQueue.Front(); item != nil; item = item.Next() {
+		allMedianGasPrice = append(allMedianGasPrice, item.Value.(*big.Int))
+	}
+	sort.Sort(bigIntArray(allMedianGasPrice))
+	finalGasPrice := allMedianGasPrice[(len(allMedianGasPrice)-1)*percentile/100]
+	medianGasPriceQueue.Remove(medianGasPriceQueue.Front())
+	return finalGasPrice
+}
+
+type bigIntArray []*big.Int
+
+func (s bigIntArray) Len() int           { return len(s) }
+func (s bigIntArray) Less(i, j int) bool { return s[i].Cmp(s[j]) < 0 }
+func (s bigIntArray) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }


### PR DESCRIPTION
### Description

Optimize l1 gas price calculation.

### Rationale

The current L1 gas price is a fixed value. This value can't truly reflect the L1 gas price and needs to be adjusted. The median gas price of the latest 21 blocks(21 validators in bsc) is calculated.

### Example

n/a

### Changes

Notable changes:
* Add new `Snow` hard fork to change L1 gas price.
* Rename `OPBNBDevnet` to `OPBNBQANet` and update info.
* Optimize log description.
