### PR TITLE
feat: add snow hardfork mainnet time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## v0.3.1
+
+This is a hardfork release for the opBNB Mainnet called Snow. It will be activated at April 9, 2024, at 6 AM UTC.
+All mainnet nodes must upgrade to this release before the hardfork.
+
+### User Facing Changes
+
+- The L1 gas price of all L2 transactions will be optimized after the snow hardfork. The price will be calculated based on the median of the last 21 blocks' gas prices on BSC. The L1 gas price for the opBNB Mainnet is expected to be decreased to 1 Gwei after the hardfork. And it will adjust automatically if the gas price on BSC changes.
+
+### Partial Changelog
+
+- #169: feat: optimize l1 gas price calculation after snow hardfork
+
+### Docker Images
+
+- ghcr.io/bnb-chain/op-node:v0.3.1
+- ghcr.io/bnb-chain/op-batcher:v0.3.1
+- ghcr.io/bnb-chain/op-proposer:v0.3.1
+
+### Full Changelog
+
+https://github.com/bnb-chain/opbnb/compare/v0.3.0...v0.3.1
+
 ## v0.3.0
 
 This is a recommended release for op-node. This release brings in upstream updates, see https://github.com/bnb-chain/opbnb/pull/121 for the contents. This is also a ready release for the next planed fork, which will bring in canyon fork from upstream as well.

--- a/op-node/chaincfg/chains.go
+++ b/op-node/chaincfg/chains.go
@@ -141,8 +141,7 @@ var OPBNBMainnet = rollup.Config{
 	L1SystemConfigAddress:  common.HexToAddress("0x7ac836148c14c74086d57f7828f2d065672db3b8"),
 	RegolithTime:           u64Ptr(0),
 	Fermat:                 big.NewInt(9397477), // Nov-28-2023 06 AM +UTC
-	// TODO update timestamp
-	SnowTime: nil,
+	SnowTime:               u64Ptr(1712642400),  // Apr-09-2024 06 AM +UTC
 }
 
 var OPBNBTestnet = rollup.Config{


### PR DESCRIPTION
### Description

Add snow hardfork mainnet time.

### Rationale

The current L1 gas price is currently a fixed value, but it may not accurately reflect the true L1 gas price and needs to be adjusted. The median gas price of the latest 21 blocks (21 validators in BSC) will be calculated after the upcoming hardfork scheduled for April 9, 2024, at 06:00 AM UT. For more details, please refer to <https://github.com/bnb-chain/opbnb/pull/169>.

### Example

NA

### Changes

Notable changes:
* NA
