### PR TITLE
feature(op-node): simplify op-node start

### DIFF
--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -49,7 +49,7 @@ var (
 		Name:    "rpc.addr",
 		Usage:   "RPC listening address",
 		EnvVars: prefixEnvVars("RPC_ADDR"),
-		Value:   "0.0.0.0",
+		Value:   "127.0.0.1",
 	}
 	RPCListenPort = &cli.IntFlag{
 		Name:    "rpc.port",
@@ -61,7 +61,6 @@ var (
 		Name:    "rpc.enable-admin",
 		Usage:   "Enable the admin API (experimental)",
 		EnvVars: prefixEnvVars("RPC_ENABLE_ADMIN"),
-		Value:   true,
 	}
 	RPCAdminPersistence = &cli.StringFlag{
 		Name:    "rpc.admin-state",
@@ -72,7 +71,6 @@ var (
 		Name:    "l1.trustrpc",
 		Usage:   "Trust the L1 RPC, sync faster at risk of malicious/buggy RPC providing bad or inconsistent L1 data",
 		EnvVars: prefixEnvVars("L1_TRUST_RPC"),
-		Value:   true,
 	}
 	L1RPCProviderKind = &cli.GenericFlag{
 		Name: "l1.rpckind",
@@ -171,7 +169,6 @@ var (
 		Name:    "metrics.enabled",
 		Usage:   "Enable the metrics server",
 		EnvVars: prefixEnvVars("METRICS_ENABLED"),
-		Value:   true,
 	}
 	MetricsAddrFlag = &cli.StringFlag{
 		Name:    "metrics.addr",
@@ -189,7 +186,6 @@ var (
 		Name:    "pprof.enabled",
 		Usage:   "Enable the pprof server",
 		EnvVars: prefixEnvVars("PPROF_ENABLED"),
-		Value:   true,
 	}
 	PprofAddrFlag = &cli.StringFlag{
 		Name:    "pprof.addr",

--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -49,18 +49,19 @@ var (
 		Name:    "rpc.addr",
 		Usage:   "RPC listening address",
 		EnvVars: prefixEnvVars("RPC_ADDR"),
-		Value:   "127.0.0.1",
+		Value:   "0.0.0.0",
 	}
 	RPCListenPort = &cli.IntFlag{
 		Name:    "rpc.port",
 		Usage:   "RPC listening port",
 		EnvVars: prefixEnvVars("RPC_PORT"),
-		Value:   9545, // Note: op-service/rpc/cli.go uses 8545 as the default.
+		Value:   7000, // Note: op-service/rpc/cli.go uses 8545 as the default.
 	}
 	RPCEnableAdmin = &cli.BoolFlag{
 		Name:    "rpc.enable-admin",
 		Usage:   "Enable the admin API (experimental)",
 		EnvVars: prefixEnvVars("RPC_ENABLE_ADMIN"),
+		Value:   true,
 	}
 	RPCAdminPersistence = &cli.StringFlag{
 		Name:    "rpc.admin-state",
@@ -105,7 +106,7 @@ var (
 		Name:    "l1.http-poll-interval",
 		Usage:   "Polling interval for latest-block subscription when using an HTTP RPC provider. Ignored for other types of RPC endpoints.",
 		EnvVars: prefixEnvVars("L1_HTTP_POLL_INTERVAL"),
-		Value:   time.Second * 12,
+		Value:   time.Second * 3,
 	}
 	L2EngineJWTSecret = &cli.StringFlag{
 		Name:        "l2.jwt-secret",
@@ -120,7 +121,7 @@ var (
 		Usage:    "Number of L1 blocks to keep distance from the L1 head before deriving L2 data from. Reorgs are supported, but may be slow to perform.",
 		EnvVars:  prefixEnvVars("VERIFIER_L1_CONFS"),
 		Required: false,
-		Value:    0,
+		Value:    15,
 	}
 	SequencerEnabledFlag = &cli.BoolFlag{
 		Name:    "sequencer.enabled",
@@ -149,14 +150,14 @@ var (
 		Usage:    "Number of L1 blocks to keep distance from the L1 head as a sequencer for picking an L1 origin.",
 		EnvVars:  prefixEnvVars("SEQUENCER_L1_CONFS"),
 		Required: false,
-		Value:    4,
+		Value:    15,
 	}
 	L1EpochPollIntervalFlag = &cli.DurationFlag{
 		Name:     "l1.epoch-poll-interval",
 		Usage:    "Poll interval for retrieving new L1 epoch updates such as safe and finalized block changes. Disabled if 0 or negative.",
 		EnvVars:  prefixEnvVars("L1_EPOCH_POLL_INTERVAL"),
 		Required: false,
-		Value:    time.Second * 12 * 32,
+		Value:    time.Second * 3 * 15,
 	}
 	RuntimeConfigReloadIntervalFlag = &cli.DurationFlag{
 		Name:     "l1.runtime-config-reload-interval",
@@ -169,6 +170,7 @@ var (
 		Name:    "metrics.enabled",
 		Usage:   "Enable the metrics server",
 		EnvVars: prefixEnvVars("METRICS_ENABLED"),
+		Value:   true,
 	}
 	MetricsAddrFlag = &cli.StringFlag{
 		Name:    "metrics.addr",
@@ -186,6 +188,7 @@ var (
 		Name:    "pprof.enabled",
 		Usage:   "Enable the pprof server",
 		EnvVars: prefixEnvVars("PPROF_ENABLED"),
+		Value:   true,
 	}
 	PprofAddrFlag = &cli.StringFlag{
 		Name:    "pprof.addr",
@@ -238,7 +241,7 @@ var (
 		Usage:    "Enables or disables execution engine P2P sync",
 		EnvVars:  prefixEnvVars("L2_ENGINE_SYNC_ENABLED"),
 		Required: false,
-		Value:    false,
+		Value:    true,
 	}
 	SkipSyncStartCheck = &cli.BoolFlag{
 		Name: "l2.skip-sync-start-check",
@@ -246,7 +249,7 @@ var (
 			"This defers the L1-origin verification, and is recommended to use in when utilizing l2.engine-sync",
 		EnvVars:  prefixEnvVars("L2_SKIP_SYNC_START_CHECK"),
 		Required: false,
-		Value:    false,
+		Value:    true,
 	}
 	BetaExtraNetworks = &cli.BoolFlag{
 		Name:    "beta.extra-networks",

--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -72,6 +72,7 @@ var (
 		Name:    "l1.trustrpc",
 		Usage:   "Trust the L1 RPC, sync faster at risk of malicious/buggy RPC providing bad or inconsistent L1 data",
 		EnvVars: prefixEnvVars("L1_TRUST_RPC"),
+		Value:   true,
 	}
 	L1RPCProviderKind = &cli.GenericFlag{
 		Name: "l1.rpckind",

--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -55,7 +55,7 @@ var (
 		Name:    "rpc.port",
 		Usage:   "RPC listening port",
 		EnvVars: prefixEnvVars("RPC_PORT"),
-		Value:   7000, // Note: op-service/rpc/cli.go uses 8545 as the default.
+		Value:   9545, // Note: op-service/rpc/cli.go uses 8545 as the default.
 	}
 	RPCEnableAdmin = &cli.BoolFlag{
 		Name:    "rpc.enable-admin",

--- a/op-node/flags/p2p_flags.go
+++ b/op-node/flags/p2p_flags.go
@@ -148,14 +148,14 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			Name:     ListenTCPPortName,
 			Usage:    "TCP port to bind LibP2P to. Any available system port if set to 0.",
 			Required: false,
-			Value:    9222,
+			Value:    9003,
 			EnvVars:  p2pEnv(envPrefix, "LISTEN_TCP_PORT"),
 		},
 		&cli.UintFlag{
 			Name:     ListenUDPPortName,
 			Usage:    "UDP port to bind Discv5 to. Same as TCP port if left 0.",
 			Required: false,
-			Value:    0, // can simply match the TCP libp2p port
+			Value:    9003, // can simply match the TCP libp2p port
 			EnvVars:  p2pEnv(envPrefix, "LISTEN_UDP_PORT"),
 		},
 		&cli.StringFlag{


### PR DESCRIPTION
### Description

Simplify op-node start

### Rationale

Currently, starting op-node requires manual setting of many parameters. In order to facilitate users to start nodes, some default configuration added for opBNB mainnet and testnet.

### Example

Currently, there are two network configurations, opBNB mainnet and testnet by default. You can select the corresponding network configuration by setting `--network= opBNBMainnet ` or `--network=opBNBTestnet`.  You also need to set some config manually:
* `--l1=L1_RPC`
* `--l2=L2_RPC`
* `--l2.jwt-secret=./jwt.txt`
* `--snapshotlog.file=./snapshot.log`

For example:
```
 ./geth --network= opBNBMainnet --l2.jwt-secret=./jwt.txt --l1=L1_RPC --l2=L2_RPC --snapshotlog.file=./snapshot.log
```
```
  ./geth --network= opBNBTestnet --l2.jwt-secret=./jwt.txt --l1=L1_RPC --l2=L2_RPC --snapshotlog.file=./snapshot.log

```



### Changes

Notable changes:
* add some default settings for `opBNB`

