### PR TITLE
fix: fix devnet after 1.7.2 upstream merge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,9 +146,11 @@ devnet-test: pre-devnet
 
 devnet-down:
 	@(cd ./ops-bedrock && GENESIS_TIMESTAMP=$(shell date +%s) docker compose stop)
+	if [ -f "./.devnet/node-deploy/start_cluster.sh" ]; then ./.devnet/node-deploy/start_cluster.sh stop; fi
 .PHONY: devnet-down
 
 devnet-clean:
+	if [ -f "./.devnet/node-deploy/start_cluster.sh" ]; then ./.devnet/node-deploy/start_cluster.sh stop; fi
 	rm -rf ./packages/contracts-bedrock/deployments/devnetL1
 	rm -rf ./.devnet
 	cd ./ops-bedrock && docker compose down

--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,10 @@ devnet-up: pre-devnet
 	PYTHONPATH=./bedrock-devnet $(PYTHON) ./bedrock-devnet/main.py --monorepo-dir=.
 .PHONY: devnet-up
 
+devnet-init: pre-devnet
+	PYTHONPATH=./bedrock-devnet $(PYTHON) ./bedrock-devnet/main.py --monorepo-dir=. --init
+.PHONY: devnet-init
+
 devnet-test: pre-devnet
 	PYTHONPATH=./bedrock-devnet $(PYTHON) ./bedrock-devnet/main.py --monorepo-dir=. --test
 .PHONY: devnet-test

--- a/bedrock-devnet/README.md
+++ b/bedrock-devnet/README.md
@@ -12,6 +12,9 @@ Tips:
 
 Install Foundry by following [the instructions located here](https://getfoundry.sh/).
 
+Please make sure your Foundry version matches the one described in versions.json.
+If they do not match, please use a command such as `foundryup -C xxxxxx` to modify it.
+
 # usage
 First, execute `pnpm install` and `pnpm build` commands in the root directory.
 

--- a/bedrock-devnet/README.md
+++ b/bedrock-devnet/README.md
@@ -6,7 +6,7 @@ It allows us to quickly start the devnet locally (with L1 network as BSC network
 
 # requirement
 
-docker, nodejs 16+, yarn, foundry, python2, python3, pnpm
+docker, nodejs 16+, yarn, foundry, python3, pnpm, poetry, go, jq
 
 Tips:
 

--- a/bedrock-devnet/devnet/__init__.py
+++ b/bedrock-devnet/devnet/__init__.py
@@ -277,6 +277,7 @@ def devnet_deploy(paths):
     log.info('Generating network config.')
     devnet_cfg_orig = pjoin(paths.contracts_bedrock_dir, 'deploy-config', 'devnetL1.json')
     devnet_cfg_backup = pjoin(paths.devnet_dir, 'devnetL1.json.bak')
+    devnet_cfg_final = pjoin(paths.devnet_dir, 'devnetL1.json')
     shutil.copy(devnet_cfg_orig, devnet_cfg_backup)
     deploy_config = read_json(devnet_cfg_orig)
     deploy_config['l1ChainID'] = int(bscChainId,10)
@@ -317,6 +318,7 @@ def devnet_deploy(paths):
     deploy_config['l1GenesisBlockTimestamp'] = l1BlockTimestamp
     deploy_config['l1StartingBlockTag'] = l1BlockTag
     write_json(devnet_cfg_orig, deploy_config)
+    write_json(devnet_cfg_final, deploy_config)
 
     if os.path.exists(paths.genesis_l2_path):
         log.info('L2 genesis and rollup configs already generated.')

--- a/bedrock-devnet/devnet/__init__.py
+++ b/bedrock-devnet/devnet/__init__.py
@@ -298,6 +298,9 @@ def devnet_deploy(paths):
     deploy_config['proxyAdminOwner'] = l1_init_holder
     deploy_config['finalSystemOwner'] = l1_init_holder
     deploy_config['governanceTokenOwner'] = l1_init_holder
+    deploy_config['l2GenesisDeltaTimeOffset'] = "0x1"
+    deploy_config['fermat'] = 0
+    deploy_config['L2GenesisEcotoneTimeOffset'] = "0x2"
     write_json(devnet_cfg_orig, deploy_config)
 
     if os.path.exists(paths.addresses_json_path):

--- a/ops-bedrock/Dockerfile.l1
+++ b/ops-bedrock/Dockerfile.l1
@@ -1,20 +1,16 @@
-FROM golang:1.19-alpine3.18 as build
+FROM golang:1.21-alpine3.18 as build
 RUN apk add --no-cache git make cmake gcc musl-dev linux-headers build-base libc-dev gcompat
 RUN git clone https://github.com/bnb-chain/bsc.git
-RUN cd bsc && git checkout v1.2.12 && make geth && go build -o ./build/bin/bootnode ./cmd/bootnode
-RUN git clone https://github.com/bnb-chain/node.git
-RUN cd node && git checkout v0.10.16 && make build
+RUN cd bsc && git checkout v1.4.5 && make geth && go build -o ./build/bin/bootnode ./cmd/bootnode
 
-FROM golang:1.19-alpine3.18
+FROM golang:1.21-alpine3.18
 
 RUN apk add --no-cache bash expect wget nodejs npm git jq make cmake gcc musl-dev linux-headers build-base libc-dev gcompat python3
 
 RUN mkdir /db
 RUN cd /db && git clone https://github.com/bnb-chain/node-deploy.git
-RUN cd /db/node-deploy && git checkout 7492b04275c6e802acc90868e29b6a0a34b8849b && make tool
+RUN cd /db/node-deploy && git checkout 27e7ca669a27c8fd259eeb88ba33ef5a1b4ac182
 COPY --from=build /go/bsc/build/bin/geth /db/node-deploy/bin/geth
 COPY --from=build /go/bsc/build/bin/bootnode /db/node-deploy/bin/bootnode
-COPY --from=build /go/node/build/tbnbcli /db/node-deploy/bin/tbnbcli
-COPY --from=build /go/node/build/bnbchaind /db/node-deploy/bin/bnbchaind
 
 ENTRYPOINT ["/bin/sh", "/l1-entrypoint.sh"]

--- a/ops-bedrock/docker-compose.yml
+++ b/ops-bedrock/docker-compose.yml
@@ -21,21 +21,6 @@ services:
     image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-stack-go:devnet
     entrypoint: ["echo", "build complete"]
 
-  l1:
-    build:
-      context: .
-      dockerfile: Dockerfile.l1
-    ports:
-      - "8545:8545"
-      - "7060:6060"
-    env_file:
-      - ./l1.env
-    user: root
-    volumes:
-      - "l1_data:/db"
-      - "./l1-entrypoint.sh:/l1-entrypoint.sh"
-    entrypoint: /l1-entrypoint.sh
-
   l2:
     build:
       context: .
@@ -57,7 +42,6 @@ services:
   op-node:
     depends_on:
       - op_stack_go_builder
-      - l1
       - l2
     build:
       context: ../
@@ -68,7 +52,7 @@ services:
     command: >
       op-node
       --l1.trustrpc
-      --l1=http://l1:8545
+      --l1=http://host.docker.internal:8545
       --l2=http://l2:8551
       --l2.jwt-secret=/config/test-jwt-secret.txt
       --sequencer.enabled
@@ -91,8 +75,11 @@ services:
       --pprof.enabled
       --rpc.enable-admin
       --log.level=debug
+      --sequencer.priority
+      --l1.max-concurrency=20
     ports:
       - "7545:8545"
+      - "8545:9545"
       - "7300:7300"
       - "6060:6060"
     volumes:
@@ -105,7 +92,6 @@ services:
   op-proposer:
     depends_on:
       - op_stack_go_builder
-      - l1
       - l2
       - op-node
     build:
@@ -119,7 +105,7 @@ services:
       - "7302:7300"
       - "6546:8545"
     environment:
-      OP_PROPOSER_L1_ETH_RPC: http://l1:8545
+      OP_PROPOSER_L1_ETH_RPC: http://host.docker.internal:8545
       OP_PROPOSER_ROLLUP_RPC: http://op-node:8545
       OP_PROPOSER_POLL_INTERVAL: 1s
       OP_PROPOSER_NUM_CONFIRMATIONS: 4
@@ -140,7 +126,6 @@ services:
   op-batcher:
     depends_on:
       - op_stack_go_builder
-      - l1
       - l2
       - op-node
     build:
@@ -154,7 +139,7 @@ services:
       - "7301:7300"
       - "6545:8545"
     environment:
-      OP_BATCHER_L1_ETH_RPC: http://l1:8545
+      OP_BATCHER_L1_ETH_RPC: http://host.docker.internal:8545
       OP_BATCHER_L2_ETH_RPC: http://l2:8545
       OP_BATCHER_ROLLUP_RPC: http://op-node:8545
       OP_BATCHER_MAX_L1_TX_SIZE_BYTES: 120000
@@ -162,7 +147,7 @@ services:
       OP_BATCHER_TARGET_NUM_FRAMES: 30
       OP_BATCHER_APPROX_COMPR_RATIO: "0.4"
       OP_BATCHER_MAX_CHANNEL_DURATION: 20
-      OP_BATCHER_POLL_INTERVAL: 1s
+      OP_BATCHER_POLL_INTERVAL: 5s
       OP_BATCHER_SAFE_ABORT_NONCE_TOO_LOW_COUNT: 3
       OP_BATCHER_NUM_CONFIRMATIONS: 4
       OP_BATCHER_TXMGR_RECEIPT_QUERY_INTERVAL: 1s
@@ -175,12 +160,13 @@ services:
       OP_BATCHER_BATCH_TYPE: 0
       OP_BATCHER_LOG_TERMINAL: "true"
       OP_BATCHER_SUB_SAFETY_MARGIN: 30 # SWS is 15, ChannelTimeout is 40
-      OP_BATCHER_MAX_PENDING_TX: 100
+      OP_BATCHER_MAX_PENDING_TX: 40
+      OP_BATCHER_TXMGR_MIN_TIP_CAP: 0
+      OP_BATCHER_TXMGR_MIN_BASEFEE: 0
 
   op-challenger:
     depends_on:
       - op_stack_go_builder
-      - l1
       - l2
       - op-node
     build:
@@ -210,13 +196,3 @@ services:
       OP_CHALLENGER_HD_PATH: "m/44'/60'/0'/0/4"
       OP_CHALLENGER_NUM_CONFIRMATIONS: 1
 
-  artifact-server:
-    depends_on:
-      - l1
-    image: nginx:1.25-alpine
-    ports:
-      - "8080:80"
-    volumes:
-      - "${PWD}/../.devnet/:/usr/share/nginx/html/:ro"
-    security_opt:
-      - "no-new-privileges:true"

--- a/ops-bedrock/docker-compose.yml
+++ b/ops-bedrock/docker-compose.yml
@@ -5,7 +5,6 @@ version: '3.4'
 # service.
 
 volumes:
-  l1_data:
   l2_data:
   op_log:
 
@@ -144,7 +143,7 @@ services:
       OP_BATCHER_ROLLUP_RPC: http://op-node:8545
       OP_BATCHER_MAX_L1_TX_SIZE_BYTES: 120000
       OP_BATCHER_TARGET_L1_TX_SIZE_BYTES: 100000
-      OP_BATCHER_TARGET_NUM_FRAMES: 30
+      OP_BATCHER_TARGET_NUM_FRAMES: 6
       OP_BATCHER_APPROX_COMPR_RATIO: "0.4"
       OP_BATCHER_MAX_CHANNEL_DURATION: 20
       OP_BATCHER_POLL_INTERVAL: 5s
@@ -157,12 +156,13 @@ services:
       OP_BATCHER_PPROF_ENABLED: "true"
       OP_BATCHER_METRICS_ENABLED: "true"
       OP_BATCHER_RPC_ENABLE_ADMIN: "true"
-      OP_BATCHER_BATCH_TYPE: 0
+      OP_BATCHER_BATCH_TYPE: 1
       OP_BATCHER_LOG_TERMINAL: "true"
       OP_BATCHER_SUB_SAFETY_MARGIN: 30 # SWS is 15, ChannelTimeout is 40
       OP_BATCHER_MAX_PENDING_TX: 40
       OP_BATCHER_TXMGR_MIN_TIP_CAP: 0
       OP_BATCHER_TXMGR_MIN_BASEFEE: 0
+      OP_BATCHER_DATA_AVAILABILITY_TYPE: "blobs"
 
   op-challenger:
     depends_on:

--- a/ops-bedrock/l1-entrypoint.sh
+++ b/ops-bedrock/l1-entrypoint.sh
@@ -1,39 +1,9 @@
 #!/usr/bin/env bash
 set -eou
-cd /db
-if [ ! -f solc-linux-amd64-v0.6.4+commit.1dca32f3 ]; then
-  wget https://github.com/ethereum/solc-bin/raw/gh-pages/linux-amd64/solc-linux-amd64-v0.6.4%2Bcommit.1dca32f3
-  cp solc-linux-amd64-v0.6.4+commit.1dca32f3 /usr/bin/solc
-  chmod +x /usr/bin/solc
-else
-  echo "solc already exists"
-fi
+cd /db/node-deploy
 
-cd node-deploy
-git submodule update --init --recursive
-cd genesis
-npm install
-cd ..
-
-sed -i -e "s/INIT_HOLDER=\"0x04d63aBCd2b9b1baa327f2Dda0f873F197ccd186\"/INIT_HOLDER=\"$INIT_HOLDER\"/g" .env
-sed -i -e "s/INIT_HOLDER_PRV=\"59ba8068eb256d520179e903f43dacf6d8d57d72bd306e1bd603fdb8c8da10e8\"/INIT_HOLDER_PRV=\"$INIT_HOLDER_PRV\"/g" .env
-
-if [ ! -f init_file_bc ]; then
-  bash +x ./setup_bc_node.sh native_init
-  echo "finish" > init_file_bc
-else
-  echo "bc init already finish"
-fi
-bash +x ./setup_bc_node.sh native_start
-
-if [ ! -f init_file_bsc ]; then
-  bash +x ./setup_bsc_node.sh native_init
-  echo "finish" > init_file_bsc
-else
-  echo "bsc init already finish"
-fi
-bash +x ./setup_bsc_node.sh native_start
-
+echo "starting..."
+bash -x ./start_cluster.sh start
 
 while true; do
     sleep 1000

--- a/packages/contracts-bedrock/scripts/Config.sol
+++ b/packages/contracts-bedrock/scripts/Config.sol
@@ -94,7 +94,7 @@ library Config {
             return "optimism-goerli";
         } else if (chainid == Chains.OPMainnet) {
             return "optimism-mainnet";
-        } else if (chainid == Chains.LocalDevnet || chainid == Chains.GethDevnet) {
+        } else if (chainid == Chains.LocalDevnet || chainid == Chains.GethDevnet || chainid == Chains.BscDevnet) {
             return "devnetL1";
         } else if (chainid == Chains.Hardhat) {
             return "hardhat";


### PR DESCRIPTION
### Description

After merging the code from upstream version 1.7.2, we need to make some modifications to ensure that our Devnet scripts continue to function properly. Among them, we need to test the ability to submit blobs for BSC as L1, so I have made significant changes to the Devnet deployment process for BSC.

### Rationale

After merging upstream code, fix our Devnet script.

### Example

After this PR, you can still use the `make devnet-up` command to start Devnet. For more details, please refer to the content of the bedrock-devnet/README.md file.

### Changes

Notable changes:
* Fix Devnet script
