### PR TITLE
op-node: set finalityDelay to 15 to speed up finality update

### DIFF
--- a/op-node/rollup/derive/engine_queue.go
+++ b/op-node/rollup/derive/engine_queue.go
@@ -134,7 +134,7 @@ const finalityLookback = 4*32 + 1
 
 // finalityDelay is the number of L1 blocks to traverse before trying to finalize L2 blocks again.
 // We do not want to do this too often, since it requires fetching a L1 block by number, so no cache data.
-const finalityDelay = 64
+const finalityDelay = 15
 
 // calcFinalityLookback calculates the default finality lookback based on DA challenge window if plasma
 // mode is activated or L1 finality lookback.


### PR DESCRIPTION
### Description

set `const finalityDelay` to 15 to speed up finality update
### Rationale

speed up finality update
### Example

n/a
### Changes

Notable changes:
set `const finalityDelay` to 15 to speed up finality update

