### PR TITLE
feature: add haber fork config in deployment script

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -253,7 +253,7 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ethereum/go-ethereum v1.13.8 => github.com/bnb-chain/op-geth v0.4.1-0.20240514082730-f8d1c9e18803
+replace github.com/ethereum/go-ethereum v1.13.8 => github.com/bnb-chain/op-geth v0.4.1
 
 replace github.com/cometbft/cometbft => github.com/bnb-chain/greenfield-cometbft v1.0.0
 

--- a/go.mod
+++ b/go.mod
@@ -253,7 +253,7 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ethereum/go-ethereum v1.13.8 => github.com/bnb-chain/op-geth v0.4.2
+replace github.com/ethereum/go-ethereum v1.13.8 => github.com/bnb-chain/op-geth v0.4.1
 
 replace github.com/cometbft/cometbft => github.com/bnb-chain/greenfield-cometbft v1.0.0
 

--- a/go.mod
+++ b/go.mod
@@ -253,7 +253,7 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ethereum/go-ethereum v1.13.8 => github.com/bnb-chain/op-geth v0.4.1
+replace github.com/ethereum/go-ethereum v1.13.8 => github.com/bnb-chain/op-geth v0.4.2
 
 replace github.com/cometbft/cometbft => github.com/bnb-chain/greenfield-cometbft v1.0.0
 

--- a/go.sum
+++ b/go.sum
@@ -179,8 +179,8 @@ github.com/bits-and-blooms/bitset v1.10.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
 github.com/bnb-chain/greenfield-cometbft v1.0.0 h1:0r6hOJWD/+es0gxP/exKuN/krgXAr3LCn5/XlcgDWr8=
 github.com/bnb-chain/greenfield-cometbft v1.0.0/go.mod h1:f35mk/r5ab6yvzlqEWZt68LfUje68sYgMpVlt2CUYMk=
-github.com/bnb-chain/op-geth v0.4.1-0.20240514082730-f8d1c9e18803 h1:DBJAzHTOzLoRQ04tr22dHjSLW/QclnGsOzp1wo6WoBs=
-github.com/bnb-chain/op-geth v0.4.1-0.20240514082730-f8d1c9e18803/go.mod h1:dkpInaOz3WeP/5lgdL0BOA6mjexUj30tPQU81H1yEHQ=
+github.com/bnb-chain/op-geth v0.4.1 h1:rnVDtFWHhg0RBSndIBeh6M9cNOPzbW8XfshWY6jWIUQ=
+github.com/bnb-chain/op-geth v0.4.1/go.mod h1:dkpInaOz3WeP/5lgdL0BOA6mjexUj30tPQU81H1yEHQ=
 github.com/boltdb/bolt v1.3.1 h1:JQmyP4ZBrce+ZQu0dY660FMfatumYDLun9hBCUVIkF4=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=

--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -228,6 +228,9 @@ type DeployConfig struct {
 	// SnowTimeOffset is the number of seconds after genesis block that snow hard fork activates.
 	// Set it to 0 to activate at genesis. Nil to disable snow fork.
 	SnowTimeOffset *hexutil.Uint64 `json:"snowTimeOffset,omitempty"`
+	// HaberTimeOffset is the number of seconds after genesis block that haber hard fork activates.
+	// Set it to 0 to activate at genesis. Nil to disable haber fork.
+	HaberTimeOffset *hexutil.Uint64 `json:"haberTimeOffset,omitempty"`
 	// RequiredProtocolVersion indicates the protocol version that
 	// nodes are required to adopt, to stay in sync with the network.
 	RequiredProtocolVersion params.ProtocolVersion `json:"requiredProtocolVersion"`
@@ -562,6 +565,17 @@ func (d *DeployConfig) SnowTime(genesisTime uint64) *uint64 {
 	}
 	v := uint64(0)
 	if offset := *d.SnowTimeOffset; offset > 0 {
+		v = genesisTime + uint64(offset)
+	}
+	return &v
+}
+
+func (d *DeployConfig) HaberTime(genesisTime uint64) *uint64 {
+	if d.HaberTimeOffset == nil {
+		return nil
+	}
+	v := uint64(0)
+	if offset := *d.HaberTimeOffset; offset > 0 {
 		v = genesisTime + uint64(offset)
 	}
 	return &v

--- a/op-chain-ops/genesis/genesis.go
+++ b/op-chain-ops/genesis/genesis.go
@@ -68,6 +68,7 @@ func NewL2Genesis(config *DeployConfig, block *types.Block) (*core.Genesis, erro
 		EcotoneTime:                   config.EcotoneTime(block.Time()),
 		InteropTime:                   config.InteropTime(block.Time()),
 		Fermat:                        config.Fermat,
+		HaberTime:                     config.HaberTime(block.Time()),
 		Optimism: &params.OptimismConfig{
 			EIP1559Denominator:       eip1559Denom,
 			EIP1559Elasticity:        eip1559Elasticity,

--- a/op-node/withdrawals/proof.go
+++ b/op-node/withdrawals/proof.go
@@ -8,7 +8,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/ethclient/gethclient"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/trie"
 )
@@ -59,7 +58,7 @@ func VerifyAccountProof(root common.Hash, address common.Address, account types.
 	}
 }
 
-func VerifyStorageProof(root common.Hash, proof gethclient.StorageResult) error {
+func VerifyStorageProof(root common.Hash, proof common.StorageResult) error {
 	secureKey := crypto.Keccak256(common.FromHex(proof.Key))
 	db := GenerateProofDB(proof.Proof)
 	value, err := trie.VerifyProof(root, secureKey, db)
@@ -75,7 +74,7 @@ func VerifyStorageProof(root common.Hash, proof gethclient.StorageResult) error 
 	}
 }
 
-func VerifyProof(stateRoot common.Hash, proof *gethclient.AccountResult) error {
+func VerifyProof(stateRoot common.Hash, proof *common.AccountResult) error {
 	err := VerifyAccountProof(
 		stateRoot,
 		proof.Address,

--- a/op-node/withdrawals/utils.go
+++ b/op-node/withdrawals/utils.go
@@ -7,22 +7,20 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
+	"github.com/ethereum-optimism/optimism/op-bindings/bindingspreview"
+	"github.com/ethereum-optimism/optimism/op-bindings/predeploys"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/ethclient/gethclient"
-
-	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
-	"github.com/ethereum-optimism/optimism/op-bindings/bindingspreview"
-	"github.com/ethereum-optimism/optimism/op-bindings/predeploys"
 )
 
 var MessagePassedTopic = crypto.Keccak256Hash([]byte("MessagePassed(uint256,address,address,uint256,uint256,bytes,bytes32)"))
 
 type ProofClient interface {
-	GetProof(context.Context, common.Address, []string, *big.Int) (*gethclient.AccountResult, error)
+	GetProof(context.Context, common.Address, []string, *big.Int) (*common.AccountResult, error)
 }
 
 type ReceiptClient interface {

--- a/packages/contracts-bedrock/scripts/getting-started/config.sh
+++ b/packages/contracts-bedrock/scripts/getting-started/config.sh
@@ -101,6 +101,7 @@ config=$(cat << EOL
   "preimageOracleChallengePeriod": 86400,
   "fermat": 0,
   "snowTimeOffset": "0x0",
+  "haberTimeOffset": "0x0",
   "fundDevAccounts": true,
   "proofMaturityDelaySeconds": 12,
   "disputeGameFinalityDelaySeconds": 6,


### PR DESCRIPTION
### Description

Add haber fork config in deployment script.

### Rationale

It is convenient for users to enable haber fork when starting a new chain.

### Example

Add `haber` hard fork.

### Changes

Notable changes:
* Add `haber` hard fork in deployment script.
