### PR TITLE
config: Mainnet canyon/delta/ecotone fork time

### DIFF
--- a/op-node/chaincfg/chains.go
+++ b/op-node/chaincfg/chains.go
@@ -142,6 +142,9 @@ var OPBNBMainnet = rollup.Config{
 	RegolithTime:           u64Ptr(0),
 	Fermat:                 big.NewInt(9397477), // Nov-28-2023 06 AM +UTC
 	SnowTime:               u64Ptr(1713160800),  // Apr-15-2024 06 AM +UTC
+	CanyonTime:             u64Ptr(1718870400),  // Jun-20-2024 08:00 AM +UTC
+	DeltaTime:              u64Ptr(1718871000),  // Jun-20-2024 08:10 AM +UTC
+	EcotoneTime:            u64Ptr(1718871600),  // Jun-20-2024 08:20 AM +UTC
 }
 
 var OPBNBTestnet = rollup.Config{


### PR DESCRIPTION
### Description

Modify the configuration to add the activation time of the Canyon, delta, and ecotone forks on the Mainnet.
Activation time is as follows:
Shanghai/Canyon Time: 2024-06-20 08:00:00 AM UTC
Delta Time: 2024-06-20 08:10:00 AM UTC
Cancun/Ecotone Time: 2024-06-20 08:20:00 AM UTC

### Rationale

We will activate these hard forks on the mainnet.

### Example

none

### Changes

Notable changes:
* Change the mainnet's default configuration to increase the hard fork activation time.
