### PR TITLE
fix(devnet): fork offset should be 0x

### DIFF
--- a/bedrock-devnet/devnet/__init__.py
+++ b/bedrock-devnet/devnet/__init__.py
@@ -287,9 +287,9 @@ def devnet_deploy(paths):
     deploy_config['proxyAdminOwner'] = l1_init_holder
     deploy_config['finalSystemOwner'] = l1_init_holder
     deploy_config['governanceTokenOwner'] = l1_init_holder
-    deploy_config['l2GenesisDeltaTimeOffset'] = "0x1"
+    deploy_config['l2GenesisDeltaTimeOffset'] = "0x0"
     deploy_config['fermat'] = 0
-    deploy_config['L2GenesisEcotoneTimeOffset'] = "0x2"
+    deploy_config['L2GenesisEcotoneTimeOffset'] = "0x0"
     write_json(devnet_cfg_orig, deploy_config)
 
     if os.path.exists(paths.addresses_json_path):


### PR DESCRIPTION
### Description

After the last merge of upstream code, our Devnet's batcher defaults to submitting blob spanbatch data, but the Delta and Ecotone hard fork configurations were not enabled in the genesis block, causing issues after devnet starts, with the safe block height not increasing. We need to fix this issue.

### Rationale

Enable Delta and Ecotone forks in the Devnet's genesis block so that batchers can submit data of type blob spanbatch.

### Example

none

### Changes

Notable changes:
* set l2GenesisDeltaTimeOffset and L2GenesisEcotoneTimeOffset to 0x0
