### PR TITLE
Fix(devnet): Repair devnet start script after 1.7.7 upstream merge

### DIFF
--- a/bedrock-devnet/devnet/__init__.py
+++ b/bedrock-devnet/devnet/__init__.py
@@ -29,6 +29,9 @@ parser.add_argument('--init', help='init BSC L1 devnet chain', type=bool, action
 
 log = logging.getLogger()
 
+# Global constants
+FORKS = ["delta", "ecotone", "fjord"]
+
 # Global environment variables
 DEVNET_NO_BUILD = os.getenv('DEVNET_NO_BUILD') == "true"
 DEVNET_FPAC = os.getenv('DEVNET_FPAC') == "true"
@@ -121,59 +124,9 @@ def main():
     git_commit = subprocess.run(['git', 'rev-parse', 'HEAD'], capture_output=True, text=True).stdout.strip()
     git_date = subprocess.run(['git', 'show', '-s', "--format=%ct"], capture_output=True, text=True).stdout.strip()
 
-    # CI loads the images from workspace, and does not otherwise know the images are good as-is
-#     if os.getenv('DEVNET_NO_BUILD') == "true":
-#         log.info('Skipping docker images build')
-#     else:
-#         log.info(f'Building docker images for git commit {git_commit} ({git_date})')
-#         run_command(['docker', 'compose', 'build', '--progress', 'plain',
-#                      '--build-arg', f'GIT_COMMIT={git_commit}', '--build-arg', f'GIT_DATE={git_date}'],
-#                     cwd=paths.ops_bedrock_dir, env={
-#             'PWD': paths.ops_bedrock_dir,
-#             'DOCKER_BUILDKIT': '1', # (should be available by default in later versions, but explicitly enable it anyway)
-#             'COMPOSE_DOCKER_CLI_BUILD': '1'  # use the docker cache
-#         })
-
     log.info('Devnet starting')
     devnet_deploy(paths)
 
-
-def deploy_contracts(paths):
-    wait_up(8545)
-    wait_for_rpc_server('http://127.0.0.1:8545')
-    res = eth_accounts('127.0.0.1:8545')
-
-    response = json.loads(res)
-    account = response['result'][0]
-    log.info(f'Deploying with {account}')
-
-    # send some ether to the create2 deployer account
-    run_command([
-        'cast', 'send', '--from', account,
-        '--rpc-url', 'http://127.0.0.1:8545',
-        '--unlocked', '--value', '1ether', '0x3fAB184622Dc19b6109349B94811493BF2a45362'
-    ], env={}, cwd=paths.contracts_bedrock_dir)
-
-    # deploy the create2 deployer
-    run_command([
-      'cast', 'publish', '--rpc-url', 'http://127.0.0.1:8545',
-      '0xf8a58085174876e800830186a08080b853604580600e600039806000f350fe7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf31ba02222222222222222222222222222222222222222222222222222222222222222a02222222222222222222222222222222222222222222222222222222222222222'
-    ], env={}, cwd=paths.contracts_bedrock_dir)
-
-    fqn = 'scripts/Deploy.s.sol:Deploy'
-    run_command([
-        'forge', 'script', fqn, '--sender', account,
-        '--rpc-url', 'http://127.0.0.1:8545', '--broadcast',
-        '--unlocked'
-    ], env={}, cwd=paths.contracts_bedrock_dir)
-
-    shutil.copy(paths.l1_deployments_path, paths.addresses_json_path)
-
-    log.info('Syncing contracts.')
-    run_command([
-        'forge', 'script', fqn, '--sig', 'sync()',
-        '--rpc-url', 'http://127.0.0.1:8545'
-    ], env={}, cwd=paths.contracts_bedrock_dir)
 
 def init_devnet_l1_deploy_config(paths, update_timestamp=False):
     deploy_config = read_json(paths.devnet_config_template_path)
@@ -193,13 +146,35 @@ def devnet_l1_genesis(paths):
     fqn = 'scripts/Deploy.s.sol:Deploy'
     run_command([
         'forge', 'script', '--chain-id', '900', fqn, "--sig", "runWithStateDump()"
-    ], env={}, cwd=paths.contracts_bedrock_dir)
+    ], env={
+      'DEPLOYMENT_OUTFILE': paths.l1_deployments_path,
+      'DEPLOY_CONFIG_PATH': paths.devnet_config_path,
+    }, cwd=paths.contracts_bedrock_dir)
 
     forge_dump = read_json(paths.forge_dump_path)
     write_json(paths.allocs_path, { "accounts": forge_dump })
     os.remove(paths.forge_dump_path)
 
     shutil.copy(paths.l1_deployments_path, paths.addresses_json_path)
+
+def devnet_l2_allocs(paths):
+    log.info('Generating L2 genesis allocs, with L1 addresses: '+paths.l1_deployments_path)
+
+    fqn = 'scripts/L2Genesis.s.sol:L2Genesis'
+    run_command([
+        'forge', 'script', fqn, "--sig", "runWithAllUpgrades()"
+    ], env={
+      'CONTRACT_ADDRESSES_PATH': paths.l1_deployments_path,
+      'DEPLOY_CONFIG_PATH': paths.devnet_config_path,
+    }, cwd=paths.contracts_bedrock_dir)
+
+    # For the previous forks, and the latest fork (default, thus empty prefix),
+    # move the forge-dumps into place as .devnet allocs.
+    for fork in FORKS:
+        input_path = pjoin(paths.contracts_bedrock_dir, f"state-dump-901-{fork}.json")
+        output_path = pjoin(paths.devnet_dir, f'allocs-l2-{fork}.json')
+        shutil.move(src=input_path, dst=output_path)
+        log.info("Generated L2 allocs: "+output_path)
 
 def deployL1ContractsForDeploy(paths):
     log.info('Starting L1.')
@@ -218,13 +193,6 @@ def deployL1ContractsForDeploy(paths):
     account = l1_init_holder
     log.info(f'Deploying with {account}')
 
-    # send some ether to the create2 deployer account
-    run_command([
-        'cast', 'send', '--private-key', l1_init_holder_prv,
-        '--rpc-url', 'http://127.0.0.1:8545', '--gas-price', '10000000000', '--legacy',
-        '--value', '1ether', '0x3fAB184622Dc19b6109349B94811493BF2a45362'
-    ], env={}, cwd=paths.contracts_bedrock_dir)
-
     # send some ether to proposer address
     run_command([
         'cast', 'send', '--private-key', l1_init_holder_prv,
@@ -239,25 +207,34 @@ def deployL1ContractsForDeploy(paths):
         '--value', '10000ether', batcher_address
     ], env={}, cwd=paths.contracts_bedrock_dir)
 
-    # deploy the create2 deployer
-    run_command([
-      'cast', 'publish', '--rpc-url', 'http://127.0.0.1:8545',
-      '0xf8a58085174876e800830186a08080b853604580600e600039806000f350fe7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf31ba02222222222222222222222222222222222222222222222222222222222222222a02222222222222222222222222222222222222222222222222222222222222222'
-    ], env={}, cwd=paths.contracts_bedrock_dir)
+    code_result=run_command(['cast', 'code','--rpc-url', 'http://127.0.0.1:8545', '0x4e59b44847b379578588920ca78fbf26c0b4956c'],env={},cwd=paths.contracts_bedrock_dir,capture_output=True)
+    if code_result.stdout=='0x\n':
+        # send some ether to the create2 deployer account
+        run_command([
+            'cast', 'send', '--private-key', l1_init_holder_prv,
+            '--rpc-url', 'http://127.0.0.1:8545', '--gas-price', '10000000000', '--legacy',
+            '--value', '1ether', '0x3fAB184622Dc19b6109349B94811493BF2a45362'
+        ], env={}, cwd=paths.contracts_bedrock_dir)
+        # deploy the create2 deployer
+        run_command([
+          'cast', 'publish', '--rpc-url', 'http://127.0.0.1:8545',
+          '0xf8a58085174876e800830186a08080b853604580600e600039806000f350fe7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf31ba02222222222222222222222222222222222222222222222222222222222222222a02222222222222222222222222222222222222222222222222222222222222222'
+        ], env={}, cwd=paths.contracts_bedrock_dir)
+    else:
+        log.info('create2 deployer already deployed')
+
 
     fqn = 'scripts/Deploy.s.sol:Deploy'
     run_command([
         'forge', 'script', fqn, '--private-key', l1_init_holder_prv, '--with-gas-price', '10000000000', '--legacy',
         '--rpc-url', 'http://127.0.0.1:8545', '--broadcast',
-    ], env={}, cwd=paths.contracts_bedrock_dir)
+    ], env={
+        'DEPLOYMENT_OUTFILE': paths.l1_deployments_path,
+        'DEPLOY_CONFIG_PATH': paths.devnet_config_path,
+    }, cwd=paths.contracts_bedrock_dir)
 
     shutil.copy(paths.l1_deployments_path, paths.addresses_json_path)
 
-#     log.info('Syncing contracts.')
-#     run_command([
-#         'forge', 'script', fqn, '--sig', 'sync()',
-#         '--rpc-url', 'http://127.0.0.1:8545'
-#     ], env={}, cwd=paths.contracts_bedrock_dir)
     log.info('Deployed L1 contracts.')
 
 # Bring up the devnet where the contracts are deployed to L1
@@ -300,6 +277,7 @@ def devnet_deploy(paths):
     deploy_config['l2GenesisDeltaTimeOffset'] = "0x0"
     deploy_config['fermat'] = 0
     deploy_config['L2GenesisEcotoneTimeOffset'] = "0x0"
+    deploy_config['L2GenesisFjordTimeOffset'] = "0x0"
     write_json(devnet_cfg_orig, deploy_config)
 
     if os.path.exists(paths.addresses_json_path):
@@ -327,10 +305,17 @@ def devnet_deploy(paths):
     else:
         log.info('Generating network config.')
         log.info('Generating L2 genesis and rollup configs.')
+        l2_allocs_path = pjoin(paths.devnet_dir, f'allocs-l2-{FORKS[-1]}.json')
+        if os.path.exists(l2_allocs_path) == False:
+          devnet_l2_allocs(paths)
+        else:
+          log.info('Re-using existing L2 allocs.')
+
         run_command([
             'go', 'run', 'cmd/main.go', 'genesis', 'l2',
             '--l1-rpc', 'http://localhost:8545',
             '--deploy-config', paths.devnet_config_path,
+            '--l2-allocs', l2_allocs_path,
             '--l1-deployments', paths.addresses_json_path,
             '--outfile.l2', paths.genesis_l2_path,
             '--outfile.rollup', paths.rollup_config_path
@@ -485,7 +470,7 @@ def run_command_preset(command: CommandPreset):
     return proc.returncode
 
 
-def run_command(args, check=True, shell=False, cwd=None, env=None, timeout=None):
+def run_command(args, check=True, shell=False, cwd=None, env=None, timeout=None,capture_output=False):
     env = env if env else {}
     return subprocess.run(
         args,
@@ -496,7 +481,9 @@ def run_command(args, check=True, shell=False, cwd=None, env=None, timeout=None)
             **env
         },
         cwd=cwd,
-        timeout=timeout
+        timeout=timeout,
+        capture_output=capture_output,
+        text=True
     )
 
 

--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -168,7 +168,7 @@ contract L2Genesis is Deployer {
         activateFjord();
 
         if (_mode == OutputMode.OUTPUT_ALL || _mode == OutputMode.DEFAULT_LATEST) {
-            writeGenesisAllocs(Config.stateDumpPath(""));
+            writeGenesisAllocs(Config.stateDumpPath("-fjord"));
         }
     }
 


### PR DESCRIPTION
### Description

After the upstream merge PR in version 1.7.7, the Devnet startup script needs to be modified to ensure that our Devnet can start normally.

### Rationale

Modify Devnet startup script

### Example

none

### Changes

Notable changes:
* Modify Devnet startup script
* Modify the parts related to fjord in L2Genesis.s.sol to cooperate with the Devnet startup script.
