### PR TITLE
(op-node) Keep consistent status when meet an unexpected el sync

### DIFF
--- a/op-node/rollup/derive/engine_controller.go
+++ b/op-node/rollup/derive/engine_controller.go
@@ -391,22 +391,18 @@ func (e *EngineController) InsertUnsafePayload(ctx context.Context, envelope *et
 		}
 	}
 
+	var (
+		needResetSafeHead      bool
+		needResetFinalizedHead bool
+	)
+
 	//process inconsistent state
 	if status.Status == eth.ExecutionInconsistent || e.checkELSyncTriggered(status.Status, err) {
 		currentL2Info, err := e.getCurrentL2Info(ctx)
 		if err != nil {
 			return NewTemporaryError(fmt.Errorf("failed to process inconsistent state: %w", err))
 		} else {
-			log.Info("engine has inconsistent state", "unsafe", currentL2Info.Unsafe.Number, "safe", currentL2Info.Safe.Number, "final", currentL2Info.Finalized.Number)
-			e.SetUnsafeHead(currentL2Info.Unsafe)
-			if currentL2Info.Safe.Number > currentL2Info.Unsafe.Number {
-				log.Info("current safe is higher than unsafe block, reset it", "set safe after", currentL2Info.Unsafe.Number, "set safe before", e.safeHead.Number)
-				e.SetSafeHead(currentL2Info.Unsafe)
-			}
-			if currentL2Info.Finalized.Number > currentL2Info.Unsafe.Number {
-				log.Info("current finalized is higher than unsafe block, reset it", "set Finalized after", currentL2Info.Unsafe.Number, "set Finalized before", e.safeHead.Number)
-				e.SetFinalizedHead(currentL2Info.Unsafe)
-			}
+			needResetSafeHead, needResetFinalizedHead = e.resetSafeAndFinalizedHead(currentL2Info)
 		}
 
 		fcuReq := eth.ForkchoiceState{
@@ -415,25 +411,9 @@ func (e *EngineController) InsertUnsafePayload(ctx context.Context, envelope *et
 			FinalizedBlockHash: e.finalizedHead.Hash,
 		}
 
-		for attempts := 0; attempts < maxFCURetryAttempts; attempts++ {
-			fcuRes, err := e.engine.ForkchoiceUpdate(ctx, &fcuReq, nil)
-			if err != nil {
-				if strings.Contains(err.Error(), "context deadline exceeded") {
-					log.Warn("Failed to share forkchoice-updated signal, attempt %d: %v", attempts+1, err)
-					time.Sleep(fcuRetryDelay)
-					continue
-				}
-				return NewTemporaryError(fmt.Errorf("engine failed to process due to error: %w", err))
-			}
-
-			if fcuRes.PayloadStatus.Status == eth.ExecutionValid {
-				log.Info("engine processed data successfully")
-				e.needFCUCall = false
-				needSyncWithEngine = true
-				break
-			} else {
-				return NewTemporaryError(fmt.Errorf("engine failed to process inconsistent data"))
-			}
+		needSyncWithEngine, err = e.trySyncingWithEngine(ctx, fcuReq)
+		if err != nil {
+			return NewTemporaryError(err)
 		}
 	}
 
@@ -456,16 +436,25 @@ func (e *EngineController) InsertUnsafePayload(ctx context.Context, envelope *et
 		currentUnsafe, _ := e.engine.L2BlockRefByLabel(ctx, eth.Unsafe)
 		//reset unsafe
 		e.SetUnsafeHead(currentUnsafe)
-		//force reset safe,finalize
-		e.SetSafeHead(currentUnsafe)
-		e.SetFinalizedHead(currentUnsafe)
-
 		fc.HeadBlockHash = currentUnsafe.Hash
-		fc.SafeBlockHash = currentUnsafe.Hash
-		fc.FinalizedBlockHash = currentUnsafe.Hash
+
+		//force reset safe,finalize if needed
+		if needResetFinalizedHead {
+			e.SetFinalizedHead(currentUnsafe)
+			fc.FinalizedBlockHash = currentUnsafe.Hash
+			needResetFinalizedHead = false
+		}
+		if needResetSafeHead {
+			e.SetSafeHead(currentUnsafe)
+			fc.SafeBlockHash = currentUnsafe.Hash
+			needResetSafeHead = false
+		}
 
 		needSyncWithEngine = false
 	}
+	// Ensure that the variables are used even if needSyncWithEngine is false
+	_ = needResetSafeHead
+	_ = needResetFinalizedHead
 
 	if e.syncStatus == syncStatusFinishedELButNotFinalized {
 		fc.SafeBlockHash = envelope.ExecutionPayload.BlockHash
@@ -494,6 +483,7 @@ func (e *EngineController) InsertUnsafePayload(ctx context.Context, envelope *et
 	}
 
 	e.needFCUCall = false
+	// unsafe will update to the latest broadcast block anyway, this will trigger an el sync in geth when meet an inconsistent state and accelerate recover progress.
 	if e.checkUpdateUnsafeHead(fcRes.PayloadStatus.Status) {
 		e.SetUnsafeHead(ref)
 	}
@@ -618,4 +608,51 @@ func (e *EngineController) getCurrentL2Info(ctx context.Context) (*sync.FindHead
 		Safe:      safe,
 		Finalized: finalized,
 	}, nil
+}
+
+// resetSafeAndFinalizedHead will reset current safe/finalized head to keep consistent with unsafe head from engine, reset safe/finalized head if current unsafe is behind them
+func (e *EngineController) resetSafeAndFinalizedHead(currentL2Info *sync.FindHeadsResult) (bool, bool) {
+	var needResetSafeHead, needResetFinalizedHead bool
+
+	log.Info("engine has inconsistent state", "unsafe", currentL2Info.Unsafe.Number, "safe", currentL2Info.Safe.Number, "final", currentL2Info.Finalized.Number)
+	e.SetUnsafeHead(currentL2Info.Unsafe)
+
+	if currentL2Info.Safe.Number > currentL2Info.Unsafe.Number {
+		log.Info("current safe is higher than unsafe block, reset it", "set safe after", currentL2Info.Unsafe.Number, "set safe before", e.safeHead.Number)
+		e.SetSafeHead(currentL2Info.Unsafe)
+		needResetSafeHead = true
+	}
+
+	if currentL2Info.Finalized.Number > currentL2Info.Unsafe.Number {
+		log.Info("current finalized is higher than unsafe block, reset it", "set Finalized after", currentL2Info.Unsafe.Number, "set Finalized before", e.safeHead.Number)
+		e.SetFinalizedHead(currentL2Info.Unsafe)
+		needResetFinalizedHead = true
+	}
+
+	return needResetSafeHead, needResetFinalizedHead
+}
+
+// trySyncingWithEngine will request engine to deleting data beyond diskroot to keep synced with current node status
+func (e *EngineController) trySyncingWithEngine(ctx context.Context, fcuReq eth.ForkchoiceState) (bool, error) {
+	for attempts := 0; attempts < maxFCURetryAttempts; attempts++ {
+		fcuRes, err := e.engine.ForkchoiceUpdate(ctx, &fcuReq, nil)
+		if err != nil {
+			if strings.Contains(err.Error(), "context deadline exceeded") {
+				log.Warn("Failed to share forkchoice-updated signal", "attempt:", attempts+1, "err", err)
+				time.Sleep(fcuRetryDelay)
+				continue
+			}
+			return false, fmt.Errorf("engine failed to process due to error: %w", err)
+		}
+
+		if fcuRes.PayloadStatus.Status == eth.ExecutionValid {
+			log.Info("engine processed data successfully")
+			e.needFCUCall = false
+			return true, nil
+		} else {
+			return false, fmt.Errorf("engine failed to process inconsistent data")
+		}
+	}
+
+	return false, fmt.Errorf("max retry attempts reached for trySyncingWithEngine")
 }

--- a/op-service/sources/engine_client.go
+++ b/op-service/sources/engine_client.go
@@ -3,6 +3,7 @@ package sources
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -136,6 +137,9 @@ func (s *EngineAPIClient) NewPayload(ctx context.Context, payload *eth.Execution
 
 	e.Trace("Received payload execution result", "status", result.Status, "latestValidHash", result.LatestValidHash, "message", result.ValidationError)
 	if err != nil {
+		if strings.Contains(err.Error(), "forced head needed for startup") {
+			return &result, err
+		}
 		e.Error("Payload execution failed", "err", err)
 		return nil, fmt.Errorf("failed to execute payload: %w", err)
 	}

--- a/op-service/sources/engine_client.go
+++ b/op-service/sources/engine_client.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/sources/caching"
@@ -137,7 +138,7 @@ func (s *EngineAPIClient) NewPayload(ctx context.Context, payload *eth.Execution
 
 	e.Trace("Received payload execution result", "status", result.Status, "latestValidHash", result.LatestValidHash, "message", result.ValidationError)
 	if err != nil {
-		if strings.Contains(err.Error(), "forced head needed for startup") {
+		if strings.Contains(err.Error(), derive.ErrELSyncTriggerUnexpected.Error()) {
 			return &result, err
 		}
 		e.Error("Payload execution failed", "err", err)


### PR DESCRIPTION
### Description

When op-geth meet an unexpected shutdown(OOM, forcekill, etc...) and the truncate operation results in the deletion of head data, the block-by-block insertion requests from op-node will trigger an EL sync in geth. This PR addresses this situation.
related geth change: [https://github.com/bnb-chain/op-geth/pull/132](url)

### Rationale

When handling unexpected EL sync triggers, state synchronization is performed based on the specific errors returned by geth.

### Example

N/A

### Changes

