### PR TITLE
feat(op-node): add l1 cache size config

### DIFF
--- a/op-chain-ops/cmd/check-derivation/main.go
+++ b/op-chain-ops/cmd/check-derivation/main.go
@@ -114,7 +114,7 @@ func newClientsFromContext(cliCtx *cli.Context) (*ethclient.Client, *sources.Eth
 		MethodResetDuration:   time.Minute,
 	}
 	cl := ethclient.NewClient(clients.L2RpcClient)
-	ethCl, err := sources.NewEthClient(client.NewBaseRPCClient(clients.L2RpcClient), log.Root(), nil, &ethClCfg)
+	ethCl, err := sources.NewEthClient(client.NewBaseRPCClient(clients.L2RpcClient), log.Root(), nil, &ethClCfg, false)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/op-e2e/setup.go
+++ b/op-e2e/setup.go
@@ -923,6 +923,7 @@ func configureL1(rollupNodeCfg *rollupNode.Config, l1Node EthInstance) {
 		BatchSize:        20,
 		HttpPollInterval: time.Millisecond * 100,
 		MaxConcurrency:   10,
+		CacheSize:        1000,
 	}
 }
 

--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -180,6 +180,13 @@ var (
 		Value:    20,
 		Category: L1RPCCategory,
 	}
+	L1RPCMaxCacheSize = &cli.IntFlag{
+		Name:     "l1.rpc-max-cache-size",
+		Usage:    "The maximum cache size of the L1 client. it should be greater than or equal to the max lag of unsafe and safe block heights. Must be greater than or equal to 1",
+		EnvVars:  prefixEnvVars("L1_RPC_MAX_CACHE_SIZE"),
+		Value:    1000,
+		Category: L1RPCCategory,
+	}
 	L1HTTPPollInterval = &cli.DurationFlag{
 		Name:     "l1.http-poll-interval",
 		Usage:    "Polling interval for latest-block subscription when using an HTTP RPC provider. Ignored for other types of RPC endpoints.",
@@ -417,6 +424,7 @@ var optionalFlags = []cli.Flag{
 	L1RPCProviderKind,
 	L1RPCRateLimit,
 	L1RPCMaxBatchSize,
+	L1RPCMaxCacheSize,
 	L1RPCMaxConcurrency,
 	L1HTTPPollInterval,
 	L1ArchiveBlobRpcAddr,

--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -182,7 +182,7 @@ var (
 	}
 	L1RPCMaxCacheSize = &cli.IntFlag{
 		Name:     "l1.rpc-max-cache-size",
-		Usage:    "The maximum cache size of the L1 client. it should be greater than or equal to the max lag of unsafe and safe block heights. Must be greater than or equal to 1",
+		Usage:    "The maximum cache size of the L1 client. it should be greater than or equal to the maximum height difference between the L1 blocks corresponding to the unsafe block height and the safe block height. Must be greater than or equal to 1",
 		EnvVars:  prefixEnvVars("L1_RPC_MAX_CACHE_SIZE"),
 		Value:    1000,
 		Category: L1RPCCategory,

--- a/op-node/node/client.go
+++ b/op-node/node/client.go
@@ -117,6 +117,9 @@ type L1EndpointConfig struct {
 	// BatchSize specifies the maximum batch-size, which also applies as L1 rate-limit burst amount (if set).
 	BatchSize int
 
+	// CacheSize specifies the maximum cache size of l1 client. it should be greater than or equal to the max lag of unsafe and safe block heights.
+	CacheSize int
+
 	// MaxConcurrency specifies the maximum number of concurrent requests to the L1 RPC.
 	MaxConcurrency int
 
@@ -132,6 +135,9 @@ var _ L1EndpointSetup = (*L1EndpointConfig)(nil)
 func (cfg *L1EndpointConfig) Check() error {
 	if cfg.BatchSize < 1 || cfg.BatchSize > 500 {
 		return fmt.Errorf("batch size is invalid or unreasonable: %d", cfg.BatchSize)
+	}
+	if cfg.CacheSize < 1 {
+		return fmt.Errorf("cache size is invalid or unreasonable: %d", cfg.CacheSize)
 	}
 	if cfg.RateLimit < 0 {
 		return fmt.Errorf("rate limit cannot be negative")
@@ -163,6 +169,10 @@ func (cfg *L1EndpointConfig) Setup(ctx context.Context, log log.Logger, rollupCf
 	rpcCfg := sources.L1ClientDefaultConfig(rollupCfg, cfg.L1TrustRPC, cfg.L1RPCKind)
 	rpcCfg.MaxRequestsPerBatch = cfg.BatchSize
 	rpcCfg.MaxConcurrentRequests = cfg.MaxConcurrency
+	rpcCfg.ReceiptsCacheSize = cfg.CacheSize
+	rpcCfg.HeadersCacheSize = cfg.CacheSize
+	rpcCfg.TransactionsCacheSize = cfg.CacheSize
+	rpcCfg.PayloadsCacheSize = cfg.CacheSize
 	return l1Node, rpcCfg, nil
 }
 
@@ -177,6 +187,10 @@ func fallbackClientWrap(ctx context.Context, logger log.Logger, urlList []string
 	rpcCfg := sources.L1ClientDefaultConfig(rollupCfg, cfg.L1TrustRPC, cfg.L1RPCKind)
 	rpcCfg.MaxRequestsPerBatch = cfg.BatchSize
 	rpcCfg.MaxConcurrentRequests = cfg.MaxConcurrency
+	rpcCfg.ReceiptsCacheSize = cfg.CacheSize
+	rpcCfg.HeadersCacheSize = cfg.CacheSize
+	rpcCfg.TransactionsCacheSize = cfg.CacheSize
+	rpcCfg.PayloadsCacheSize = cfg.CacheSize
 	return l1Node, rpcCfg, nil
 }
 

--- a/op-node/node/client.go
+++ b/op-node/node/client.go
@@ -117,7 +117,8 @@ type L1EndpointConfig struct {
 	// BatchSize specifies the maximum batch-size, which also applies as L1 rate-limit burst amount (if set).
 	BatchSize int
 
-	// CacheSize specifies the maximum cache size of l1 client. it should be greater than or equal to the max lag of unsafe and safe block heights.
+	// CacheSize specifies the maximum cache size of l1 client.
+	// it should be greater than or equal to the maximum height difference between the L1 blocks corresponding to the unsafe block height and the safe block height.
 	CacheSize int
 
 	// MaxConcurrency specifies the maximum number of concurrent requests to the L1 RPC.

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -158,6 +158,7 @@ func NewL1EndpointConfig(ctx *cli.Context) *node.L1EndpointConfig {
 		L1RPCKind:        sources.RPCProviderKind(strings.ToLower(ctx.String(flags.L1RPCProviderKind.Name))),
 		RateLimit:        ctx.Float64(flags.L1RPCRateLimit.Name),
 		BatchSize:        ctx.Int(flags.L1RPCMaxBatchSize.Name),
+		CacheSize:        ctx.Int(flags.L1RPCMaxCacheSize.Name),
 		HttpPollInterval: ctx.Duration(flags.L1HTTPPollInterval.Name),
 		MaxConcurrency:   ctx.Int(flags.L1RPCMaxConcurrency.Name),
 	}

--- a/op-service/sources/l1_client.go
+++ b/op-service/sources/l1_client.go
@@ -207,7 +207,8 @@ func (s *L1Client) GoOrUpdatePreFetchReceipts(ctx context.Context, l1Start uint6
 									}
 									if !isSuccess {
 										s.log.Debug("The receipts cache may be full. "+
-											"please ensure the difference between the safe block height and the unsafe block height is less than or equal to the cache size.",
+											"please ensure the maximum height difference between the L1 blocks "+
+											"corresponding to the unsafe block height and the safe block height is less than or equal to the cache size.",
 											"blockHash", blockInfo.Hash, "blockNumber", blockNumber)
 										time.Sleep(1 * time.Second)
 										continue

--- a/op-service/sources/l1_client.go
+++ b/op-service/sources/l1_client.go
@@ -206,7 +206,9 @@ func (s *L1Client) GoOrUpdatePreFetchReceipts(ctx context.Context, l1Start uint6
 										continue
 									}
 									if !isSuccess {
-										s.log.Debug("pre fetch receipts fail without error,need retry", "blockHash", blockInfo.Hash, "blockNumber", blockNumber)
+										s.log.Debug("The receipts cache may be full. "+
+											"please ensure the difference between the safe block height and the unsafe block height is less than or equal to the cache size.",
+											"blockHash", blockInfo.Hash, "blockNumber", blockNumber)
 										time.Sleep(1 * time.Second)
 										continue
 									}


### PR DESCRIPTION
### Description
This PR includes two changes:
1. Added a configuration item: l1.rpc-max-cache-size, with a default value of 1000. Its value must be greater than or equal to 1. It is recommended that the configured value be greater than or equal to the maximum height difference between the L1 blocks corresponding to the unsafe block height and the safe block height.
2. When the l1 receipts cache is full, log a message to remind the user.


### Rationale

In https://github.com/bnb-chain/opbnb/pull/104, I made modifications to the receipt cache of the L1 client, significantly improving the cache hit rate. However, there are some issues when the safe block height lags far behind the unsafe block height. Firstly, the L1 receipt cache data corresponding to the safe block height is only deleted from the cache after the safe block height is processed. If the safe block height lags too far behind the unsafe block height, the L1 receipt cache becomes full. This prevents the new unsafe block height from accessing the cache, triggering the optimization logic in https://github.com/bnb-chain/opbnb/pull/87, where the unsafe block height continues to produce blocks based on the same L1 block height instead of moving to the next L1 block height. Additionally, the maximum value of our cache is hardcoded in the code. If the transaction volume of the chain is too low and the batcher submission frequency is very low, it is easy for the safe block height to lag behind the unsafe block height. We need to allow users to configure the maximum value of the cache to ensure it is greater than or equal to the maximum height difference between the L1 blocks corresponding to the unsafe block height and the safe block height.
### Example

none

### Changes

Notable changes:
* see description part
