### PR TITLE
fix(op-node): alchemy as rpc node for opbnb

### DIFF
--- a/op-service/sources/l1_client.go
+++ b/op-service/sources/l1_client.go
@@ -92,7 +92,9 @@ func NewL1Client(client client.RPC, log log.Logger, metrics caching.Metrics, con
 // Notice, we cannot cache a block reference by label because labels are not guaranteed to be unique.
 func (s *L1Client) L1BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L1BlockRef, error) {
 	info, err := s.BSCInfoByLabel(ctx, label)
-	if label == eth.Finalized && err != nil && strings.Contains(err.Error(), "eth_getFinalizedHeader does not exist") {
+	if label == eth.Finalized && err != nil &&
+		(strings.Contains(err.Error(), "eth_getFinalizedHeader does not exist") ||
+			strings.Contains(err.Error(), "method not found")) {
 		// op-e2e not support bsc as L1 currently, so fallback to not use bsc specific method eth_getFinalizedBlock
 		info, err = s.InfoByLabel(ctx, label)
 	}

--- a/op-service/sources/receipts_rpc.go
+++ b/op-service/sources/receipts_rpc.go
@@ -325,7 +325,7 @@ const (
 func AvailableReceiptsFetchingMethods(kind RPCProviderKind) ReceiptsFetchingMethod {
 	switch kind {
 	case RPCKindAlchemy:
-		return AlchemyGetTransactionReceipts | EthGetBlockReceipts | EthGetTransactionReceiptBatch
+		return EthGetTransactionReceiptBatch
 	case RPCKindQuickNode:
 		return DebugGetRawReceipts | EthGetBlockReceipts | EthGetTransactionReceiptBatch
 	case RPCKindInfura:

--- a/op-service/sources/receipts_test.go
+++ b/op-service/sources/receipts_test.go
@@ -240,22 +240,6 @@ func TestEthClient_FetchReceipts(t *testing.T) {
 
 	testCases := []ReceiptsTestCase{
 		{
-			name:         "alchemy",
-			providerKind: RPCKindAlchemy,
-			setup:        fallbackCase(30, AlchemyGetTransactionReceipts),
-		},
-		{
-			name:         "alchemy sticky",
-			providerKind: RPCKindAlchemy,
-			staticMethod: true,
-			setup:        fallbackCase(30, AlchemyGetTransactionReceipts, AlchemyGetTransactionReceipts),
-		},
-		{
-			name:         "alchemy fallback 1",
-			providerKind: RPCKindAlchemy,
-			setup:        fallbackCase(40, AlchemyGetTransactionReceipts, EthGetBlockReceipts),
-		},
-		{
 			name:         "alchemy low tx count cost saving",
 			providerKind: RPCKindAlchemy,
 			// when it's cheaper to fetch individual receipts than the alchemy-bundled receipts we change methods.


### PR DESCRIPTION
### Description

Fix: #228 

### Changes

When using alchemy as `L1_RPC_KIND`:

- fallback to `EthGetTransactionReceiptBatch
- check error message