### PR TITLE
fix(op-service): fallback client failed to switch URL in txmgr

### DIFF
--- a/op-service/fallbackclient/dial.go
+++ b/op-service/fallbackclient/dial.go
@@ -76,7 +76,7 @@ func DialEthClientWithTimeoutAndFallback(ctx context.Context, url string, timeou
 			return nil, err
 		}
 		fallbackClient := NewFallbackClient(firstEthClient, urlList, l, fallbackThreshold, m, func(url string) (Client, error) {
-			ethClientNew, err := DialEthClientWithTimeout(ctx, timeout, l, url)
+			ethClientNew, err := DialEthClientWithTimeout(context.Background(), timeout, l, url)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
### Description

When initializing txmgr, the context passed to DialEthClientWithTimeoutAndFallback is one that will be immediately closed, which I did not notice. When a switch occurs, the fallback client uses the already closed context to establish a connection with the next URL, causing the switch to fail.

### Rationale

Modify the code to use `context.Background()` in `clientInitFunc` to ensure a successful connection to the next URL.

### Example

none

### Changes

Notable changes:
* Modified the logic in DialEthClientWithTimeoutAndFallback
* ...
