### PR TITLE
feature(op-node): add Fjord hard fork time

### DIFF
--- a/op-node/chaincfg/chains.go
+++ b/op-node/chaincfg/chains.go
@@ -142,6 +142,7 @@ var OPBNBMainnet = rollup.Config{
 	CanyonTime:             u64Ptr(1718870400),  // Jun-20-2024 08:00 AM +UTC
 	DeltaTime:              u64Ptr(1718871000),  // Jun-20-2024 08:10 AM +UTC
 	EcotoneTime:            u64Ptr(1718871600),  // Jun-20-2024 08:20 AM +UTC
+	FjordTime:              u64Ptr(1727157600),  // Sep-24-2024 06:00 AM +UTC
 }
 
 var OPBNBTestnet = rollup.Config{
@@ -177,6 +178,7 @@ var OPBNBTestnet = rollup.Config{
 	CanyonTime:             u64Ptr(1715753400),   // May-15-2024 06:10 AM +UTC
 	DeltaTime:              u64Ptr(1715754000),   // May-15-2024 06:20 AM +UTC
 	EcotoneTime:            u64Ptr(1715754600),   // May-15-2024 06:30 AM +UTC
+	FjordTime:              u64Ptr(1725948000),   // Sep-10-2024 06:00 AM +UTC
 }
 
 var OPBNBQANet = rollup.Config{


### PR DESCRIPTION
### Description

Modify the configuration to add the activation time of the Fjord hard fork on the Testnet.
Activation time is 2024-09-10 06:00:00 AM UTC.
Modify the configuration to add the activation time of the Fjord hard fork on the Mainnet.
Activation time is 2024-09-24 06:00:00 AM UTC.

### Rationale

We will activate the hard fork on the testnet and mainnet.

### Example

None

### Changes

Notable changes:
* Change the testnet and mainnet's default configuration to increase the hard fork activation time.
