### PR TITLE
fix(op-node): l1 client chan stuck when closed in ELSync mode

### DIFF
--- a/op-service/sources/l1_client.go
+++ b/op-service/sources/l1_client.go
@@ -152,8 +152,8 @@ func (s *L1Client) GoOrUpdatePreFetchReceipts(ctx context.Context, l1Start uint6
 			for {
 				select {
 				case <-s.done:
-					s.preFetchReceiptsClosedChan <- struct{}{}
 					s.log.Info("pre-fetching receipts done")
+					s.preFetchReceiptsClosedChan <- struct{}{}
 					return
 				case currentL1Block = <-s.preFetchReceiptsStartBlockChan:
 					s.log.Debug("pre-fetching receipts currentL1Block changed", "block", currentL1Block)

--- a/op-service/sources/l1_client.go
+++ b/op-service/sources/l1_client.go
@@ -84,7 +84,7 @@ func NewL1Client(client client.RPC, log log.Logger, metrics caching.Metrics, con
 		preFetchReceiptsOnce:           sync.Once{},
 		preFetchReceiptsStartBlockChan: make(chan uint64, 1),
 		maxConcurrentRequests:          config.MaxConcurrentRequests,
-		done:                           make(chan struct{}, 1),
+		done:                           make(chan struct{}),
 	}, nil
 }
 
@@ -259,6 +259,6 @@ func (s *L1Client) ClearReceiptsCacheBefore(blockNumber uint64) {
 }
 
 func (s *L1Client) Close() {
-	s.done <- struct{}{}
+	close(s.done)
 	s.EthClient.Close()
 }

--- a/op-service/sources/l1_client.go
+++ b/op-service/sources/l1_client.go
@@ -87,6 +87,7 @@ func NewL1Client(client client.RPC, log log.Logger, metrics caching.Metrics, con
 		l1BlockRefsCache:               caching.NewLRUCache[common.Hash, eth.L1BlockRef](metrics, "blockrefs", config.L1BlockRefsCacheSize),
 		preFetchReceiptsOnce:           sync.Once{},
 		preFetchReceiptsStartBlockChan: make(chan uint64, 1),
+		preFetchReceiptsClosedChan:     make(chan struct{}),
 		maxConcurrentRequests:          config.MaxConcurrentRequests,
 		done:                           make(chan struct{}),
 	}, nil

--- a/op-service/sources/l1_client.go
+++ b/op-service/sources/l1_client.go
@@ -84,7 +84,7 @@ func NewL1Client(client client.RPC, log log.Logger, metrics caching.Metrics, con
 		preFetchReceiptsOnce:           sync.Once{},
 		preFetchReceiptsStartBlockChan: make(chan uint64, 1),
 		maxConcurrentRequests:          config.MaxConcurrentRequests,
-		done:                           make(chan struct{}),
+		done:                           make(chan struct{}, 1),
 	}, nil
 }
 


### PR DESCRIPTION
### Description
Fixed the issue where the node might get stuck in the l1 client shutdown function when the node is in engine sync mode during shutdown.


### Rationale

When the node has not yet fully synchronized and was in engine sync mode, the `GoOrUpdatePreFetchReceipts` method is not executed. At this time, the done channel of the l1 client has no consumers. If the node is closed at this moment, it will get stuck at the l1 client close operation.
If I simply close the done channel, a `panic: Log in goroutine after Test_xxx has completed` issue will occur during e2e testing. I must ensure that the done channel is truly closed before the close method returns.

### Example

none

### Changes

Notable changes:
* Add `preFetchReceiptsClosedChan` to ensure that everything is closed before returning from the Close function
* Add `isPreFetchReceiptsRunning` to ensure that the node does not get stuck during shutdown when in Engine Sync mode.
