### PR TITLE
prepare for v0.5.1

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -42,6 +42,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          provenance: false
 
   push-op-batcher:
     runs-on: ubuntu-latest
@@ -75,6 +77,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          provenance: false
 
   push-op-proposer:
     runs-on: ubuntu-latest
@@ -108,6 +112,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          provenance: false
 
   push-op-bootnode:
     runs-on: ubuntu-latest
@@ -141,3 +147,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          provenance: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## v0.5.1
+
+This is a minor release and upgrading is optional.
+
+### What's Changed
+* fix(ci): support building arm64 architecture by @welkin22 in https://github.com/bnb-chain/opbnb/pull/239
+* fix(op-node): l1 client chan stuck when closed in ELSync mode by @welkin22 in https://github.com/bnb-chain/opbnb/pull/241
+* fix: add sync status when newpayload API meet the specific error by @krish-nr in https://github.com/bnb-chain/opbnb/pull/240
+
+### Docker Images
+
+- ghcr.io/bnb-chain/op-node:v0.5.1
+- ghcr.io/bnb-chain/op-batcher:v0.5.1
+- ghcr.io/bnb-chain/op-proposer:v0.5.1
+
+**Full Changelog**: https://github.com/bnb-chain/opbnb/compare/v0.5.0...v0.5.1
+
 ## v0.5.0
 
 This release includes code merging from the upstream version v1.7.7 along with several fixs and improvements.

--- a/op-batcher/Makefile
+++ b/op-batcher/Makefile
@@ -25,7 +25,13 @@ ifeq ($(shell uname),Darwin)
 endif
 
 op-batcher:
+ifeq ($(TARGETARCH),arm64)
+	wget https://musl.cc/aarch64-linux-musl-cross.tgz
+	tar zxf aarch64-linux-musl-cross.tgz
+	export PATH=$$PATH:/app/op-batcher/aarch64-linux-musl-cross/bin/ && env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=aarch64-linux-musl-gcc CGO_ENABLED=1 go build -v $(LDFLAGS) -o ./bin/op-batcher ./cmd
+else
 	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) go build -v $(LDFLAGS) -o ./bin/op-batcher ./cmd
+endif
 
 clean:
 	rm bin/op-batcher

--- a/op-bootnode/Makefile
+++ b/op-bootnode/Makefile
@@ -8,7 +8,13 @@ LDFLAGSSTRING +=-X main.Version=$(VERSION)
 LDFLAGS := -ldflags "$(LDFLAGSSTRING)"
 
 op-bootnode:
+ifeq ($(TARGETARCH),arm64)
+	wget https://musl.cc/aarch64-linux-musl-cross.tgz
+	tar zxf aarch64-linux-musl-cross.tgz
+	export PATH=$$PATH:/app/op-bootnode/aarch64-linux-musl-cross/bin/ && env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=aarch64-linux-musl-gcc CGO_ENABLED=1 go build -v $(LDFLAGS) -o ./bin/op-bootnode ./cmd
+else
 	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) go build -v $(LDFLAGS) -o ./bin/op-bootnode ./cmd
+endif
 
 clean:
 	rm -f bin/op-bootnode

--- a/op-node/Dockerfile
+++ b/op-node/Dockerfile
@@ -2,7 +2,7 @@ FROM --platform=$BUILDPLATFORM golang:1.21.5-alpine3.18 as builder
 
 ARG VERSION=v0.0.0
 
-RUN apk add --no-cache build-base libc-dev
+RUN apk add --no-cache build-base libc-dev wget
 RUN apk add --no-cache make gcc musl-dev linux-headers git jq bash
 
 # build op-node with the shared go.mod & go.sum files
@@ -17,10 +17,10 @@ COPY ./go.sum /app/go.sum
 COPY ./.git /app/.git
 
 WORKDIR /app/op-node
-
 RUN go mod download
 
-ARG TARGETOS TARGETARCH
+ARG TARGETOS
+ARG TARGETARCH
 
 ENV CGO_CFLAGS="-O -D__BLST_PORTABLE__"
 ENV CGO_CFLAGS_ALLOW="-O -D__BLST_PORTABLE__"

--- a/op-node/Makefile
+++ b/op-node/Makefile
@@ -26,7 +26,13 @@ ifeq ($(shell uname),Darwin)
 endif
 
 op-node:
+ifeq ($(TARGETARCH),arm64)
+	wget https://musl.cc/aarch64-linux-musl-cross.tgz
+	tar zxf aarch64-linux-musl-cross.tgz
+	export PATH=$$PATH:/app/op-node/aarch64-linux-musl-cross/bin/ && env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=aarch64-linux-musl-gcc CGO_ENABLED=1 go build -v $(LDFLAGS) -o ./bin/op-node ./cmd/main.go
+else
 	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) go build -v $(LDFLAGS) -o ./bin/op-node ./cmd/main.go
+endif
 
 clean:
 	rm bin/op-node

--- a/op-proposer/Makefile
+++ b/op-proposer/Makefile
@@ -20,7 +20,13 @@ LDFLAGSSTRING +=-X main.Version=$(VERSION)
 LDFLAGS := -ldflags "$(LDFLAGSSTRING)"
 
 op-proposer:
+ifeq ($(TARGETARCH),arm64)
+	wget https://musl.cc/aarch64-linux-musl-cross.tgz
+	tar zxf aarch64-linux-musl-cross.tgz
+	export PATH=$$PATH:/app/op-proposer/aarch64-linux-musl-cross/bin/ && env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=aarch64-linux-musl-gcc CGO_ENABLED=1 go build -v $(LDFLAGS) -o ./bin/op-proposer ./cmd
+else
 	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) go build -v $(LDFLAGS) -o ./bin/op-proposer ./cmd
+endif
 
 clean:
 	rm bin/op-proposer

--- a/op-service/sources/engine_client.go
+++ b/op-service/sources/engine_client.go
@@ -139,6 +139,7 @@ func (s *EngineAPIClient) NewPayload(ctx context.Context, payload *eth.Execution
 	e.Trace("Received payload execution result", "status", result.Status, "latestValidHash", result.LatestValidHash, "message", result.ValidationError)
 	if err != nil {
 		if strings.Contains(err.Error(), derive.ErrELSyncTriggerUnexpected.Error()) {
+			result.Status = eth.ExecutionSyncing
 			return &result, err
 		}
 		e.Error("Payload execution failed", "err", err)


### PR DESCRIPTION
## v0.5.1

This is a minor release and upgrading is optional.

### What's Changed
* fix(ci): support building arm64 architecture by @welkin22 in https://github.com/bnb-chain/opbnb/pull/239
* fix(op-node): l1 client chan stuck when closed in ELSync mode by @welkin22 in https://github.com/bnb-chain/opbnb/pull/241
* fix: add sync status when newpayload API meet the specific error by @krish-nr in https://github.com/bnb-chain/opbnb/pull/240

### Docker Images

- ghcr.io/bnb-chain/op-node:v0.5.1
- ghcr.io/bnb-chain/op-batcher:v0.5.1
- ghcr.io/bnb-chain/op-proposer:v0.5.1

**Full Changelog**: https://github.com/bnb-chain/opbnb/compare/v0.5.0...v0.5.1