### PR TITLE
op-node: change verifiedValidatorNum param of getFinalizedHeader API to -3

### DIFF
--- a/op-service/sources/eth_client.go
+++ b/op-service/sources/eth_client.go
@@ -285,7 +285,9 @@ func (s *EthClient) InfoByLabel(ctx context.Context, label eth.BlockLabel) (eth.
 func (s *EthClient) BSCInfoByLabel(ctx context.Context, label eth.BlockLabel) (eth.BlockInfo, error) {
 	// can't hit the cache when querying the head due to reorgs / changes.
 	if label == eth.Finalized {
-		return s.bscFinalizedHeader(ctx, 21)
+		// FIXME set verifiedValidatorNum to -3 before release, set it to 8 temporarily for hotfix
+		// refs: https://github.com/bnb-chain/bsc/pull/2844
+		return s.bscFinalizedHeader(ctx, 8)
 	}
 	return s.headerCall(ctx, "eth_getBlockByNumber", label)
 }

--- a/op-service/sources/eth_client.go
+++ b/op-service/sources/eth_client.go
@@ -285,9 +285,9 @@ func (s *EthClient) InfoByLabel(ctx context.Context, label eth.BlockLabel) (eth.
 func (s *EthClient) BSCInfoByLabel(ctx context.Context, label eth.BlockLabel) (eth.BlockInfo, error) {
 	// can't hit the cache when querying the head due to reorgs / changes.
 	if label == eth.Finalized {
-		// FIXME set verifiedValidatorNum to -3 before release, set it to 8 temporarily for hotfix
+		// -3 means automatically use the len(validators) of BSC network
 		// refs: https://github.com/bnb-chain/bsc/pull/2844
-		return s.bscFinalizedHeader(ctx, 8)
+		return s.bscFinalizedHeader(ctx, -3)
 	}
 	return s.headerCall(ctx, "eth_getBlockByNumber", label)
 }


### PR DESCRIPTION
### Description

change verifiedValidatorNum to -3 to automatically adapt BSC network validators
### Rationale
validators of BSC network may change, and BSC `getFinalizedHeader` API support a new feature to automatically adapt this change, you can refer to https://github.com/bnb-chain/bsc/pull/2844

we make this update to follow the new feature
### Example

n/a
### Changes
change verifiedValidatorNum to -3 to automatically adapt BSC network validators


