### PR TITLE
fix(op-node): extract err stage from rpc error when call engine_opSealPayload api

### DIFF
--- a/op-service/eth/types.go
+++ b/op-service/eth/types.go
@@ -21,15 +21,15 @@ import (
 type ErrorCode int
 
 const (
-	UnknownPayload           ErrorCode = -32001 // Payload does not exist / is not available.
+	UnknownPayload           ErrorCode = -38001 // Payload does not exist / is not available.
 	InvalidForkchoiceState   ErrorCode = -38002 // Forkchoice state is invalid / inconsistent.
 	InvalidPayloadAttributes ErrorCode = -38003 // Payload attributes are invalid / inconsistent.
 )
 
 const (
-	GetPayloadStage        = "getPayload"
-	NewPayloadStage        = "newPayload"
-	ForkchoiceUpdatedStage = "forkchoiceUpdated"
+	GetPayloadStage        = "sealApiGetPayloadErrStage"
+	NewPayloadStage        = "sealApiNewPayloadErrStage"
+	ForkchoiceUpdatedStage = "sealApiForkchoiceUpdatedErrStage"
 )
 
 var ErrBedrockScalarPaddingNotEmpty = errors.New("version 0 scalar value has non-empty padding")


### PR DESCRIPTION
### Description

This pr fix error handle of engine_opSealPaylaod api, related fix to op-geth is https://github.com/bnb-chain/op-geth/pull/255
### Rationale
The error handle of original engine_api is chaos and easy lead to bug, the new engine_opSealPayload api followed the original part, and unfortunately triggered bug, which will cause chain stuck if force kill

### Example

n/a
### Changes
extract err stage from rpc error when call engine_opSealPayload api
