### PR TITLE
chore: refine l2 attribute millisecond timestamp setter

### DIFF
--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -368,7 +368,7 @@ func l2BlockRefFromBlockAndL1Info(block *types.Block, l1info *derive.L1BlockInfo
 		Number:         block.NumberU64(),
 		ParentHash:     block.ParentHash(),
 		Time:           block.Time(),
-		MilliTime:      uint256.NewInt(0).SetBytes32(block.MixDigest().Bytes()[:]).Uint64(), // adapts millisecond part
+		MilliTime:      uint256.NewInt(0).SetBytes32(block.MixDigest().Bytes()[:]).Uint64(), // adapts l1 millisecond part
 		L1Origin:       eth.BlockID{Hash: l1info.BlockHash, Number: l1info.Number},
 		SequenceNumber: l1info.SequenceNumber,
 	}

--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -319,6 +319,8 @@ func (d *DeployConfig) L2MillisecondBlockInterval() uint64 {
 	return d.L2BlockTime * 1000
 }
 
+// L2SecondBlockInterval is just used by ut&e2e test.
+// TODO: ut&e2e need to be refined later.
 func (d *DeployConfig) L2SecondBlockInterval() uint64 {
 	if d.L2BlockTime <= 3 {
 		// has been second
@@ -465,7 +467,7 @@ func (d *DeployConfig) Check() error {
 
 	// L2 block time must always be smaller than L1 block time
 	if d.L1MillisecondBlockInterval() < d.L2MillisecondBlockInterval() {
-		return fmt.Errorf("L2 block time (%d) is larger than L1 block time (%d)", d.L2MillisecondBlockInterval(), d.L1MillisecondBlockInterval())
+		return fmt.Errorf("L2 block interval ms (%d) is larger than L1 block interval ms (%d)", d.L2MillisecondBlockInterval(), d.L1MillisecondBlockInterval())
 	}
 	if d.RequiredProtocolVersion == (params.ProtocolVersion{}) {
 		log.Warn("RequiredProtocolVersion is empty")

--- a/op-node/p2p/host_test.go
+++ b/op-node/p2p/host_test.go
@@ -261,7 +261,6 @@ func TestP2PFull(t *testing.T) {
 
 	require.NoError(t, p2pClientA.ProtectPeer(ctx, hostB.ID()))
 	require.NoError(t, p2pClientA.UnprotectPeer(ctx, hostB.ID()))
-	// TODO:
 }
 
 func TestDiscovery(t *testing.T) {

--- a/op-node/rollup/derive/attributes.go
+++ b/op-node/rollup/derive/attributes.go
@@ -5,15 +5,13 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/holiman/uint256"
-
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/bsc"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/predeploys"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
 )
 
 var (
@@ -170,16 +168,17 @@ func (ba *FetchingAttributesBuilder) PreparePayloadAttributes(ctx context.Contex
 		}
 	}
 
-	return &eth.PayloadAttributes{
-		Timestamp:             hexutil.Uint64(nextL2MilliTime / 1000),           // second part
-		PrevRandao:            uint256.NewInt(nextL2MilliTime % 1000).Bytes32(), // millisecond part
+	pa := &eth.PayloadAttributes{
+		PrevRandao:            eth.Bytes32(l1Info.MixDigest()),
 		SuggestedFeeRecipient: predeploys.SequencerFeeVaultAddr,
 		Transactions:          txs,
 		NoTxPool:              true,
 		GasLimit:              (*eth.Uint64Quantity)(&sysConfig.GasLimit),
 		Withdrawals:           withdrawals,
 		ParentBeaconBlockRoot: parentBeaconRoot,
-	}, nil
+	}
+	pa.SetMillisecondTimestamp(nextL2MilliTime)
+	return pa, nil
 }
 
 func (ba *FetchingAttributesBuilder) CachePayloadByHash(payload *eth.ExecutionPayloadEnvelope) bool {

--- a/op-node/rollup/derive/batch_queue_test.go
+++ b/op-node/rollup/derive/batch_queue_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
-	"fmt"
 	"io"
 	"math/big"
 	"math/rand"
@@ -290,8 +289,6 @@ func BatchQueueEager(t *testing.T, batchType int) {
 
 	for i := 0; i < len(expectedOutputBatches); i++ {
 		b, _, e := bq.NextBatch(context.Background(), safeHead)
-		log.Info("DEBUG: ", ", i=", i, ", b=", b, ", safe_head=", safeHead)
-		fmt.Printf("DEBUG: i=%v, b=%v, safehead=%v\n", i, b, safeHead)
 		require.ErrorIs(t, e, expectedOutputErrors[i])
 		if b == nil {
 			require.Nil(t, expectedOutputBatches[i])

--- a/op-node/rollup/derive/batches.go
+++ b/op-node/rollup/derive/batches.go
@@ -125,7 +125,7 @@ func checkSingularBatch(cfg *rollup.Config, log log.Logger, l1Blocks []eth.L1Blo
 
 	spec := rollup.NewChainSpec(cfg)
 	// Check if we ran out of sequencer time drift
-	if max := (batchOrigin.Time + spec.MaxSequencerDrift(batchOrigin.Time)) * 1000; batch.Timestamp > max {
+	if max := batchOrigin.MillisecondTimestamp() + spec.MaxSequencerDrift(batchOrigin.Time)*1000; batch.Timestamp > max {
 		if len(batch.Transactions) == 0 {
 			// If the sequencer is co-operating by producing an empty batch,
 			// then allow the batch if it was the right thing to do to maintain the L2 time >= L1 time invariant.
@@ -297,7 +297,7 @@ func checkSpanBatch(ctx context.Context, cfg *rollup.Config, log log.Logger, l1B
 
 		spec := rollup.NewChainSpec(cfg)
 		// Check if we ran out of sequencer time drift
-		if max := (l1Origin.Time + spec.MaxSequencerDrift(l1Origin.Time)) * 1000; blockTimestamp > max {
+		if max := l1Origin.MillisecondTimestamp() + spec.MaxSequencerDrift(l1Origin.Time)*1000; blockTimestamp > max {
 			if len(batch.GetBlockTransactions(i)) == 0 {
 				// If the sequencer is co-operating by producing an empty batch,
 				// then allow the batch if it was the right thing to do to maintain the L2 time >= L1 time invariant.

--- a/op-node/rollup/derive/channel_out.go
+++ b/op-node/rollup/derive/channel_out.go
@@ -8,11 +8,11 @@ import (
 	"io"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rlp"
-	"github.com/holiman/uint256"
 )
 
 var (
@@ -243,7 +243,7 @@ func BlockToSingularBatch(rollupCfg *rollup.Config, block *types.Block) (*Singul
 
 	milliPart := uint64(0)
 	if block.MixDigest() != (common.Hash{}) {
-		milliPart = uint256.NewInt(0).SetBytes32(block.MixDigest().Bytes()[:]).Uint64()
+		milliPart = uint64(eth.Bytes32(block.MixDigest())[0])*256 + uint64(eth.Bytes32(block.MixDigest())[1])
 	}
 
 	milliTimestamp := block.Time()*1000 + milliPart

--- a/op-node/rollup/derive/engine_update.go
+++ b/op-node/rollup/derive/engine_update.go
@@ -203,7 +203,7 @@ func confirmPayload(
 	}
 	metrics.RecordSequencerStepTime("forkChoiceUpdateHeads", time.Since(start))
 	log.Info("inserted block", "hash", payload.BlockHash, "number", uint64(payload.BlockNumber),
-		"state_root", payload.StateRoot, "timestamp", uint64(payload.Timestamp), "parent", payload.ParentHash,
+		"state_root", payload.StateRoot, "timestamp_ms", payload.MillisecondTimestamp(), "parent", payload.ParentHash,
 		"prev_randao", payload.PrevRandao, "fee_recipient", payload.FeeRecipient,
 		"txs", len(payload.Transactions), "update_safe", updateSafe)
 	return envelope, BlockInsertOK, nil

--- a/op-node/rollup/driver/sequencer.go
+++ b/op-node/rollup/driver/sequencer.go
@@ -99,7 +99,7 @@ func (d *Sequencer) StartBuildingBlock(ctx context.Context) error {
 	// empty blocks (other than the L1 info deposit and any user deposits). We handle this by
 	// setting NoTxPool to true, which will cause the Sequencer to not include any transactions
 	// from the transaction pool.
-	attrs.NoTxPool = attrs.MilliTimestamp() > l1Origin.MillisecondTimestamp()+d.spec.MaxSequencerDrift(l1Origin.Time)*1000
+	attrs.NoTxPool = attrs.MillisecondTimestamp() > l1Origin.MillisecondTimestamp()+d.spec.MaxSequencerDrift(l1Origin.Time)*1000
 
 	// For the Ecotone activation block we shouldn't include any sequencer transactions.
 	if d.rollupCfg.IsEcotoneActivationBlock(uint64(attrs.Timestamp)) {

--- a/op-service/eth/types.go
+++ b/op-service/eth/types.go
@@ -197,7 +197,8 @@ type ExecutionPayload struct {
 }
 
 func (payload *ExecutionPayload) MillisecondTimestamp() uint64 {
-	return uint64(payload.Timestamp) * 1000
+	milliPart := uint64(payload.PrevRandao[0])*256 + uint64(payload.PrevRandao[1])
+	return uint64(payload.Timestamp)*1000 + milliPart
 }
 
 func (payload *ExecutionPayload) ID() BlockID {
@@ -332,9 +333,19 @@ type PayloadAttributes struct {
 	GasLimit *Uint64Quantity `json:"gasLimit,omitempty"`
 }
 
-func (pa *PayloadAttributes) MilliTimestamp() uint64 {
-	// TODO:
-	return uint64(pa.Timestamp) * 1000
+func (pa *PayloadAttributes) MillisecondTimestamp() uint64 {
+	milliPart := uint64(pa.PrevRandao[0])*256 + uint64(pa.PrevRandao[1])
+	return uint64(pa.Timestamp)*1000 + milliPart
+}
+
+// SetMillisecondTimestamp is used to set millisecond timestamp.
+// [32]byte PrevRandao
+// [0][1] represent l2 millisecond's mill part.
+func (pa *PayloadAttributes) SetMillisecondTimestamp(ts uint64) {
+	pa.Timestamp = hexutil.Uint64(ts / 1000)
+	milliPartBytes := uint256.NewInt(ts % 1000).Bytes32()
+	pa.PrevRandao[0] = milliPartBytes[30]
+	pa.PrevRandao[1] = milliPartBytes[31]
 }
 
 type ExecutePayloadStatus string


### PR DESCRIPTION
### Description

Refine l2 attribute millisecond timestamp setter

### Rationale

Resue first two bytes of PrevRandao to represent the milli part of the L2 timestamp.

### Example

N/A

### Changes

Notable changes:
* attribute setter func.
