### PR TITLE
fix: fix channel manager l2 milli-part parse

### DIFF
--- a/op-node/rollup/derive/l2block_util.go
+++ b/op-node/rollup/derive/l2block_util.go
@@ -3,12 +3,10 @@ package derive
 import (
 	"fmt"
 
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/holiman/uint256"
-
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 )
 
 // L2BlockRefSource is a source for the generation of a L2BlockRef. E.g. a
@@ -56,12 +54,18 @@ func L2BlockToBlockRef(rollupCfg *rollup.Config, block L2BlockRefSource) (eth.L2
 		sequenceNumber = info.SequenceNumber
 	}
 
+	milliPart := uint64(0)
+	if block.MixDigest() != (common.Hash{}) {
+		// adapts l2 millisecond, highest 2 bytes as milli-part.
+		milliPart = uint64(eth.Bytes32(block.MixDigest())[0])*256 + uint64(eth.Bytes32(block.MixDigest())[1])
+	}
+
 	return eth.L2BlockRef{
 		Hash:           hash,
 		Number:         number,
 		ParentHash:     block.ParentHash(),
 		Time:           block.Time(),
-		MilliTime:      uint256.NewInt(0).SetBytes32(block.MixDigest().Bytes()[:]).Uint64(),
+		MilliTime:      milliPart,
 		L1Origin:       l1Origin,
 		SequenceNumber: sequenceNumber,
 	}, nil


### PR DESCRIPTION
### Description

Fix channel manager l2 milli-part parse.

### Rationale

L1 milli-part timestamp is stored by mix-digest highest 2 bytes.

### Example

N/A.

### Changes

Notable changes:
* batcher l2 milli-part parse.
