### PR TITLE
feat: L2OutputOracle uses millisecond to compute l2 timestamp after volta hardfork

### DIFF
--- a/packages/contracts-bedrock/src/L1/L2OutputOracle.sol
+++ b/packages/contracts-bedrock/src/L1/L2OutputOracle.sol
@@ -29,9 +29,6 @@ contract L2OutputOracle is Initializable, ISemver {
     /// @custom:network-specific
     uint256 public l2BlockTime;
 
-    /// @notice The time between L2 blocks in milliseconds after Volta Hardfork.
-    uint256 public constant l2MillisecondsBlockTime = 500;
-
     /// @notice The address of the challenger. Can be updated via upgrade.
     /// @custom:network-specific
     address public challenger;
@@ -44,10 +41,12 @@ contract L2OutputOracle is Initializable, ISemver {
     /// @custom:network-specific
     uint256 public finalizationPeriodSeconds;
 
+    /// @notice The time between L2 blocks in milliseconds after Volta Hardfork.
+    uint256 public constant l2MillisecondsBlockTime = 500;
+
     // TODO: compute accurate hardfork block number
     /// @notice The L2 block number of Volta Hardfork.
-    /// @custom:network-specific
-    uint256 public constant voltaBlockNumber = 138901;
+    uint256 public constant voltaBlockNumber = 0;
 
     /// @notice Emitted when an output is proposed.
     /// @param outputRoot    The output root.
@@ -329,7 +328,6 @@ contract L2OutputOracle is Initializable, ISemver {
     /// @param _l2BlockNumber The L2 block number of the target block.
     /// @return L2 timestamp of the given block in seconds.
     function computeL2Timestamp(uint256 _l2BlockNumber) public view returns (uint256) {
-        // _l2BlockNumber： 480, startingBlockNumber: 0, l2BlockTime: 1
         return startingTimestamp + ((_l2BlockNumber - startingBlockNumber) * l2BlockTime);
     }
 

--- a/packages/contracts-bedrock/src/L1/L2OutputOracle.sol
+++ b/packages/contracts-bedrock/src/L1/L2OutputOracle.sol
@@ -316,7 +316,7 @@ contract L2OutputOracle is Initializable, ISemver {
     /// @notice Checks the given l2 block number is valid.
     /// @param _l2BlockNumber The L2 block number of the target block.
     /// @return True that can submit output root, otherwise false.
-    function isL2TimestampValid(uint256 _l2BlockNumber) public view returns (uint256) {
+    function isL2TimestampValid(uint256 _l2BlockNumber) public view returns (bool) {
         uint256 l2Timestamp = block.number <= voltaBlockNumber
             ? computeL2Timestamp(_l2BlockNumber)
             : computeL2TimestampAfterVolta(_l2BlockNumber);

--- a/packages/contracts-bedrock/src/L1/L2OutputOracle.sol
+++ b/packages/contracts-bedrock/src/L1/L2OutputOracle.sol
@@ -29,7 +29,7 @@ contract L2OutputOracle is Initializable, ISemver {
     /// @custom:network-specific
     uint256 public l2BlockTime;
 
-    /// @notice The time between L2 blocks in milliseconds) after Volta Hardfork.
+    /// @notice The time between L2 blocks in milliseconds after Volta Hardfork.
     /// @custom:network-specific
     uint256 public constant l2MillisecondsBlockTime = 500;
 

--- a/packages/contracts-bedrock/src/L1/L2OutputOracle.sol
+++ b/packages/contracts-bedrock/src/L1/L2OutputOracle.sol
@@ -30,7 +30,6 @@ contract L2OutputOracle is Initializable, ISemver {
     uint256 public l2BlockTime;
 
     /// @notice The time between L2 blocks in milliseconds after Volta Hardfork.
-    /// @custom:network-specific
     uint256 public constant l2MillisecondsBlockTime = 500;
 
     /// @notice The address of the challenger. Can be updated via upgrade.
@@ -46,9 +45,9 @@ contract L2OutputOracle is Initializable, ISemver {
     uint256 public finalizationPeriodSeconds;
 
     // TODO: compute accurate hardfork block number
-    /// @notice The block number of Volta Hardfork.
+    /// @notice The L2 block number of Volta Hardfork.
     /// @custom:network-specific
-    uint256 public constant voltaBlockNumber = 1000;
+    uint256 public constant voltaBlockNumber = 138901;
 
     /// @notice Emitted when an output is proposed.
     /// @param outputRoot    The output root.
@@ -317,11 +316,11 @@ contract L2OutputOracle is Initializable, ISemver {
     /// @param _l2BlockNumber The L2 block number of the target block.
     /// @return True that can submit output root, otherwise false.
     function isL2TimestampValid(uint256 _l2BlockNumber) public view returns (bool) {
-        uint256 l2Timestamp = block.number <= voltaBlockNumber
+        uint256 l2Timestamp = _l2BlockNumber <= voltaBlockNumber
             ? computeL2Timestamp(_l2BlockNumber)
             : computeL2TimestampAfterVolta(_l2BlockNumber);
 
-        uint256 currentTimestamp = block.number <= voltaBlockNumber ? block.timestamp : block.timestamp * 1000;
+        uint256 currentTimestamp = _l2BlockNumber <= voltaBlockNumber ? block.timestamp : block.timestamp * 1000;
 
         return l2Timestamp < currentTimestamp;
     }
@@ -330,6 +329,7 @@ contract L2OutputOracle is Initializable, ISemver {
     /// @param _l2BlockNumber The L2 block number of the target block.
     /// @return L2 timestamp of the given block in seconds.
     function computeL2Timestamp(uint256 _l2BlockNumber) public view returns (uint256) {
+        // _l2BlockNumber： 480, startingBlockNumber: 0, l2BlockTime: 1
         return startingTimestamp + ((_l2BlockNumber - startingBlockNumber) * l2BlockTime);
     }
 

--- a/packages/contracts-bedrock/test/L1/L2OutputOracle.t.sol
+++ b/packages/contracts-bedrock/test/L1/L2OutputOracle.t.sol
@@ -197,6 +197,35 @@ contract L2OutputOracle_getter_Test is CommonTest {
             l2OutputOracle.computeL2Timestamp(startingBlockNumber + 96024), startingTimestamp + l2BlockTime * 96024
         );
     }
+
+    function test_isL2TimestampValid_before_hardfork_succeeds() external {
+        uint256 startingBlockNumber = deploy.cfg().l2OutputOracleStartingBlockNumber();
+        assertEq(startingBlockNumber, 1);
+        uint256 startingTimestamp = deploy.cfg().l2OutputOracleStartingTimestamp();
+        assertEq(startingTimestamp, 1);
+        uint256 l2BlockTime = deploy.cfg().l2BlockTime();
+        assertEq(l2BlockTime, 2);
+
+        vm.warp(138901 * 2 + 1);
+        l2OutputOracle.isL2TimestampValid(138901);
+    }
+
+    function test_isL2TimestampValid_after_hardfork_succeeds() external {
+        uint256 startingBlockNumber = deploy.cfg().l2OutputOracleStartingBlockNumber();
+        uint256 startingTimestamp = deploy.cfg().l2OutputOracleStartingTimestamp();
+        uint256 l2BlockTime = deploy.cfg().l2BlockTime();
+
+        vm.roll(140100);
+        l2OutputOracle.isL2TimestampValid(140000);
+    }
+
+    function test_computeL2TimestampAfterVolta_succeeds() external {
+        uint256 startingBlockNumber = deploy.cfg().l2OutputOracleStartingBlockNumber();
+        uint256 startingTimestamp = deploy.cfg().l2OutputOracleStartingTimestamp();
+        uint256 l2BlockTime = deploy.cfg().l2BlockTime();
+
+        l2OutputOracle.computeL2TimestampAfterVolta(140000);
+    }
 }
 
 contract L2OutputOracle_proposeL2Output_Test is CommonTest {


### PR DESCRIPTION
### Description

L2OutputOracle uses millisecond to compute l2 timestamp after Volta Hardfork.

### Rationale

Current opBNB block time is 1s per block. After Volta Hardfork, opBNB block time is 500ms per block. `L2OutputOracle.sol` contract computes l2 timestamp by l2BlockNumber which is not right after Volta Hardfork. Therefore, add `computeL2TimestampAfterVolta` function to compute new l2 timestamp.

### Example

N/A

### Changes

Notable changes:
* `l2MillisecondsBlockTime` constant is used to record new l2 block time.
* `voltaBlockNumber` constant is used to record hardfork block number.
* `isL2TimestampValid` function is used to verify the computed l2 timestamp is valid.
* `computeL2TimestampAfterVolta` function is used to new  l2 timestamp.
