### PR TITLE
feat: set block interval to engine api

### DIFF
--- a/op-node/rollup/derive/attributes.go
+++ b/op-node/rollup/derive/attributes.go
@@ -181,7 +181,8 @@ func (ba *FetchingAttributesBuilder) PreparePayloadAttributes(ctx context.Contex
 	}
 
 	isVoltaTime := ba.rollupCfg.IsVolta(nextL2MilliTime / 1000)
-	pa.SetMillisecondTimestamp(nextL2MilliTime, isVoltaTime)
+	blockIntervalCount := ba.rollupCfg.MillisecondBlockInterval(nextL2MilliTime) / eth.BlockMillisecondsIntervalUint
+	pa.SetMillisecondTimestamp(nextL2MilliTime, isVoltaTime, blockIntervalCount)
 	if isVoltaTime {
 		log.Debug("succeed to build payload attributes after fork",
 			"timestamp_ms", nextL2MilliTime, "seconds-timestamp", pa.Timestamp,

--- a/op-service/eth/types.go
+++ b/op-service/eth/types.go
@@ -35,7 +35,7 @@ const (
 
 var ErrBedrockScalarPaddingNotEmpty = errors.New("version 0 scalar value has non-empty padding")
 
-var BlockMillisecondsIntervalUint uint64 = 500
+const BlockMillisecondsIntervalUint uint64 = 250
 
 // InputError distinguishes an user-input error from regular rpc errors,
 // to help the (Engine) API user divert from accidental input mistakes.

--- a/op-service/eth/types.go
+++ b/op-service/eth/types.go
@@ -5,7 +5,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"github.com/ethereum/go-ethereum/log"
 	"math"
 	"math/big"
 	"reflect"
@@ -15,6 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/trie"
 	"github.com/holiman/uint256"
 )


### PR DESCRIPTION
### Description

The op-node writes the BlockInterval into the third byte of the `PrevRandao` in `PayloadAttributes`, with each unit representing 500ms.

### Rationale

op-geth has more control over block time. Previously, if the BlockTime configuration of op-node was greater than 1 second, the excess time would be wasted.

[op-geth](https://github.com/bnb-chain/op-geth/pull/279)

### Example

NO.

### Changes

Notable changes:
NO.
