### PR TITLE
feat: Mainnet L2OutputOracle contract supports volta hardfork

### DIFF
--- a/packages/contracts-bedrock/contracts/L1/L2OutputOracle.sol
+++ b/packages/contracts-bedrock/contracts/L1/L2OutputOracle.sol
@@ -62,7 +62,7 @@ contract L2OutputOracle is Initializable, Semver {
     /**
      * @notice The L2 block number of Volta Hardfork.
      */
-    uint256 public constant VOLTA_BLOCK_NUMBER = 0;
+    uint256 public constant VOLTA_BLOCK_NUMBER = 53450677;
 
     /**
      * @notice Emitted when an output is proposed.


### PR DESCRIPTION
### Description

opBNB Mainnet L2OutputOracle.sol contract supports 500ms block time.

### Rationale

N/A

### Example

N/A

### Changes

Notable changes:
* N/A
