### PR TITLE
chore: update op-geth dependency for adapt new l1 hash cal

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -277,7 +277,7 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ethereum/go-ethereum v1.13.15 => github.com/bnb-chain/op-geth v1.101315.2-0.0.20250213114253-fbecb252643d
+replace github.com/ethereum/go-ethereum v1.13.15 => github.com/bnb-chain/op-geth v1.101315.2-0.0.20250418091555-2b39d61b7cbf
 
 replace github.com/cometbft/cometbft => github.com/bnb-chain/greenfield-cometbft v1.0.0
 

--- a/go.sum
+++ b/go.sum
@@ -184,8 +184,8 @@ github.com/bnb-chain/fastssz v0.1.2 h1:vTcXw5SwCtRYnl/BEclujiml7GXiVOZ74tub4GHpv
 github.com/bnb-chain/fastssz v0.1.2/go.mod h1:KcabV+OEw2QwgyY8Fc88ZG79CKYkFdu0kKWyfA3dI6o=
 github.com/bnb-chain/greenfield-cometbft v1.0.0 h1:0r6hOJWD/+es0gxP/exKuN/krgXAr3LCn5/XlcgDWr8=
 github.com/bnb-chain/greenfield-cometbft v1.0.0/go.mod h1:f35mk/r5ab6yvzlqEWZt68LfUje68sYgMpVlt2CUYMk=
-github.com/bnb-chain/op-geth v1.101315.2-0.0.20250213114253-fbecb252643d h1:zYSisO6VUWaQzieOnP7NcEXfwbcYa86CipNS+sXHb7Q=
-github.com/bnb-chain/op-geth v1.101315.2-0.0.20250213114253-fbecb252643d/go.mod h1:hyHrrcHkUe3lRwfJs+JGrbOHp+pRdheRk+ren4TPhF8=
+github.com/bnb-chain/op-geth v1.101315.2-0.0.20250418091555-2b39d61b7cbf h1:7Ry/NtfhCFelZRVhw5cPwveX8uVFchalL+qhUcn5CMA=
+github.com/bnb-chain/op-geth v1.101315.2-0.0.20250418091555-2b39d61b7cbf/go.mod h1:hyHrrcHkUe3lRwfJs+JGrbOHp+pRdheRk+ren4TPhF8=
 github.com/boltdb/bolt v1.3.1 h1:JQmyP4ZBrce+ZQu0dY660FMfatumYDLun9hBCUVIkF4=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=


### PR DESCRIPTION
### Description

Update op-geth dependency for adapt new l1 hash cal.

### Rationale

Refer to https://github.com/bnb-chain/op-geth/pull/284.

### Example

N/A.

### Changes

Notable changes:
* op-geth dependency.
