### PR TITLE
fix: arm cross platform build tool

### DIFF
--- a/op-batcher/Makefile
+++ b/op-batcher/Makefile
@@ -26,9 +26,9 @@ endif
 
 op-batcher:
 ifeq ($(TARGETARCH),arm64)
-	wget https://musl.cc/aarch64-linux-musl-cross.tgz
-	tar zxf aarch64-linux-musl-cross.tgz
-	export PATH=$$PATH:/app/op-batcher/aarch64-linux-musl-cross/bin/ && env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=aarch64-linux-musl-gcc CGO_ENABLED=1 go build -v $(LDFLAGS) -o ./bin/op-batcher ./cmd
+	wget https://ziglang.org/download/0.13.0/zig-linux-x86_64-0.13.0.tar.xz
+	tar -xf zig-linux-x86_64-0.13.0.tar.xz
+	export PATH=$$PATH:/app/op-batcher/zig-linux-x86_64-0.13.0/ && env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC="zig cc -target aarch64-linux-musl" CGO_ENABLED=1 go build -v $(LDFLAGS) -o ./bin/op-batcher ./cmd
 else
 	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) go build -v $(LDFLAGS) -o ./bin/op-batcher ./cmd
 endif

--- a/op-bootnode/Makefile
+++ b/op-bootnode/Makefile
@@ -9,9 +9,9 @@ LDFLAGS := -ldflags "$(LDFLAGSSTRING)"
 
 op-bootnode:
 ifeq ($(TARGETARCH),arm64)
-	wget https://musl.cc/aarch64-linux-musl-cross.tgz
-	tar zxf aarch64-linux-musl-cross.tgz
-	export PATH=$$PATH:/app/op-bootnode/aarch64-linux-musl-cross/bin/ && env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=aarch64-linux-musl-gcc CGO_ENABLED=1 go build -v $(LDFLAGS) -o ./bin/op-bootnode ./cmd
+	wget https://ziglang.org/download/0.13.0/zig-linux-x86_64-0.13.0.tar.xz
+	tar -xf zig-linux-x86_64-0.13.0.tar.xz
+	export PATH=$$PATH:/app/op-bootnode/zig-linux-x86_64-0.13.0/ && env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC="zig cc -target aarch64-linux-musl" CGO_ENABLED=1 go build -v $(LDFLAGS) -o ./bin/op-bootnode ./cmd
 else
 	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) go build -v $(LDFLAGS) -o ./bin/op-bootnode ./cmd
 endif

--- a/op-node/Makefile
+++ b/op-node/Makefile
@@ -27,9 +27,9 @@ endif
 
 op-node:
 ifeq ($(TARGETARCH),arm64)
-	wget https://musl.cc/aarch64-linux-musl-cross.tgz
-	tar zxf aarch64-linux-musl-cross.tgz
-	export PATH=$$PATH:/app/op-node/aarch64-linux-musl-cross/bin/ && env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=aarch64-linux-musl-gcc CGO_ENABLED=1 go build -v $(LDFLAGS) -o ./bin/op-node ./cmd/main.go
+	wget https://ziglang.org/download/0.13.0/zig-linux-x86_64-0.13.0.tar.xz
+	tar -xf zig-linux-x86_64-0.13.0.tar.xz
+	export PATH=$$PATH:/app/op-node/zig-linux-x86_64-0.13.0/ && env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC="zig cc -target aarch64-linux-musl" CGO_ENABLED=1 go build -v $(LDFLAGS) -o ./bin/op-node ./cmd/main.go
 else
 	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) go build -v $(LDFLAGS) -o ./bin/op-node ./cmd/main.go
 endif

--- a/op-proposer/Makefile
+++ b/op-proposer/Makefile
@@ -21,9 +21,9 @@ LDFLAGS := -ldflags "$(LDFLAGSSTRING)"
 
 op-proposer:
 ifeq ($(TARGETARCH),arm64)
-	wget https://musl.cc/aarch64-linux-musl-cross.tgz
-	tar zxf aarch64-linux-musl-cross.tgz
-	export PATH=$$PATH:/app/op-proposer/aarch64-linux-musl-cross/bin/ && env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC=aarch64-linux-musl-gcc CGO_ENABLED=1 go build -v $(LDFLAGS) -o ./bin/op-proposer ./cmd
+	wget https://ziglang.org/download/0.13.0/zig-linux-x86_64-0.13.0.tar.xz
+	tar -xf zig-linux-x86_64-0.13.0.tar.xz
+	export PATH=$$PATH:/app/op-proposer/zig-linux-x86_64-0.13.0/ && env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CC="zig cc -target aarch64-linux-musl" CGO_ENABLED=1 go build -v $(LDFLAGS) -o ./bin/op-proposer ./cmd
 else
 	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) go build -v $(LDFLAGS) -o ./bin/op-proposer ./cmd
 endif


### PR DESCRIPTION
### Description

Fix the arm build failure when downloading the musl cross-chain tool. Replace the tool with the Zig cross-build tool.

### Rationale

N/A

### Example

N/A

### Changes

Notable changes:
* N/A
