### PR TITLE
fix: add testnet fourier hardfork time

### DIFF
--- a/op-node/chaincfg/chains.go
+++ b/op-node/chaincfg/chains.go
@@ -181,6 +181,7 @@ var OPBNBTestnet = rollup.Config{
 	EcotoneTime:            u64Ptr(1715754600),   // May-15-2024 06:30 AM +UTC
 	FjordTime:              u64Ptr(1725948000),   // Sep-10-2024 06:00 AM +UTC
 	VoltaTime:              u64Ptr(1743562800),   // Apr-02-2025 03:00 AM +UTC
+	FourierTime:            u64Ptr(1762398000),   // Nov-06-2025 03:00 AM +UTC
 }
 
 var OPBNBQANet = rollup.Config{


### PR DESCRIPTION
### Description

Add opBNB Testnet Fourier hardfork time: Nov-06-2025 03:00 AM +UTC

### Rationale

N/A

### Example

N/A

### Changes

Notable changes:
* N/A
