### PR TITLE
fix: support compile opbnb in golang1.24.x and Windows OS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -276,8 +276,7 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-// v1.101315.2-0.0.20250418091555-2b39d61b7cbf
-replace github.com/ethereum/go-ethereum v1.13.15 => github.com/bnb-chain/op-geth v1.101315.2-0.0.20251103131439-c51e91a217c5
+replace github.com/ethereum/go-ethereum v1.13.15 => github.com/bnb-chain/op-geth v1.101315.2-0.0.20251118081547-f1c2b5af43c5
 
 replace github.com/cometbft/cometbft => github.com/bnb-chain/greenfield-cometbft v1.0.0
 

--- a/go.sum
+++ b/go.sum
@@ -184,8 +184,8 @@ github.com/bnb-chain/fastssz v0.1.2 h1:vTcXw5SwCtRYnl/BEclujiml7GXiVOZ74tub4GHpv
 github.com/bnb-chain/fastssz v0.1.2/go.mod h1:KcabV+OEw2QwgyY8Fc88ZG79CKYkFdu0kKWyfA3dI6o=
 github.com/bnb-chain/greenfield-cometbft v1.0.0 h1:0r6hOJWD/+es0gxP/exKuN/krgXAr3LCn5/XlcgDWr8=
 github.com/bnb-chain/greenfield-cometbft v1.0.0/go.mod h1:f35mk/r5ab6yvzlqEWZt68LfUje68sYgMpVlt2CUYMk=
-github.com/bnb-chain/op-geth v1.101315.2-0.0.20251103131439-c51e91a217c5 h1:E5He1qqFAr8dP+ImwDZ6ZVSk+sqZZWS0O8tfJdgg284=
-github.com/bnb-chain/op-geth v1.101315.2-0.0.20251103131439-c51e91a217c5/go.mod h1:T1sVGwAA96KwS72B62aRTvlM/a+byeIAx9Akh18eWDQ=
+github.com/bnb-chain/op-geth v1.101315.2-0.0.20251118081547-f1c2b5af43c5 h1:FVG+wugCxufwMTL7HdnaxUDWa7AGAK4TkQjNTFRL/RM=
+github.com/bnb-chain/op-geth v1.101315.2-0.0.20251118081547-f1c2b5af43c5/go.mod h1:T1sVGwAA96KwS72B62aRTvlM/a+byeIAx9Akh18eWDQ=
 github.com/boltdb/bolt v1.3.1 h1:JQmyP4ZBrce+ZQu0dY660FMfatumYDLun9hBCUVIkF4=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=


### PR DESCRIPTION
### Description

Support compile opbnb in golang1.24.x and Windows OS.

### Rationale

N/A

### Example

N/A

### Changes

Notable changes:
* N/A
