### PR TITLE
fix: buffer alt-sync range request channel to avoid driver stall

### DIFF
--- a/op-chain-ops/cmd/check-fjord/checks/checks.go
+++ b/op-chain-ops/cmd/check-fjord/checks/checks.go
@@ -51,6 +51,12 @@ var (
 	valid7212Data = common.FromHex("4cee90eb86eaa050036147a12d49004b6b9c72bd725d39d4785011fe190f0b4da73bd4903f0ce3b639bbbf6e8e80d16931ff4bcf5993d58468e8fb19086e8cac36dbcd03009df8c59286b162af3bd7fcc0450c9aa81be5d10d312af6c66b1d604aebd3099c618202fcfe16ae7770b0c49ab5eadf74b754204a3bb6060e44eff37618b065f9832de4ca6ca971a7a1adc826d0f7c00181a5fb2ddf79ae00b4e10e")
 )
 
+func isReceiptNotReady(err error) bool {
+	return errors.Is(err, ethereum.NotFound) ||
+		strings.Contains(err.Error(), "not found") ||
+		strings.Contains(err.Error(), "transaction indexing is in progress")
+}
+
 func CheckRIP7212(ctx context.Context, env *CheckFjordConfig) error {
 	env.Log.Info("checking rip-7212")
 	// invalid request returns empty response, this is how the spec denotes an error.
@@ -347,7 +353,7 @@ func execTx(ctx context.Context, to *common.Address, data []byte, expectRevert b
 		env.Log.Info("checking confirmation...", "txhash", signedTx.Hash())
 		receipt, err := env.L2.TransactionReceipt(context.Background(), signedTx.Hash())
 		if err != nil {
-			if strings.Contains(err.Error(), "not found") {
+			if isReceiptNotReady(err) {
 				env.Log.Info("not found yet, waiting...")
 				time.Sleep(time.Second)
 				continue

--- a/op-chain-ops/cmd/check-fjord/checks/checks_test.go
+++ b/op-chain-ops/cmd/check-fjord/checks/checks_test.go
@@ -1,0 +1,28 @@
+package checks
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsReceiptNotReady(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "ethereum not found", err: ethereum.NotFound, want: true},
+		{name: "legacy not found message", err: errors.New("transaction not found"), want: true},
+		{name: "transaction indexing", err: errors.New("transaction indexing is in progress"), want: true},
+		{name: "other RPC error", err: errors.New("connection reset"), want: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, isReceiptNotReady(test.err))
+		})
+	}
+}

--- a/op-node/p2p/sync.go
+++ b/op-node/p2p/sync.go
@@ -290,7 +290,7 @@ func NewSyncClient(log log.Logger, cfg *rollup.Config, newStream newStreamFn, rc
 		payloadByNumber:     PayloadByNumberProtocolID(cfg.L2ChainID),
 		peers:               make(map[peer.ID]context.CancelFunc),
 		quarantineByNum:     make(map[uint64]common.Hash),
-		rangeRequests:       make(chan rangeRequest), // blocking
+		rangeRequests:       make(chan rangeRequest, 16), // buffered, so the caller's event loop does not stall on a busy main loop
 		activeRangeRequests: newRequestIdMap(),
 		peerRequests:        make(chan peerRequest, 128),
 		results:             make(chan syncResult, 128),


### PR DESCRIPTION
### Description

Make the p2p alt-sync `rangeRequests` channel buffered (capacity 16) instead of unbuffered, so that `SyncClient.RequestL2Range` does not park the caller's goroutine while the sync client's main loop is busy.

### Rationale

The driver eventLoop and the p2p `SyncClient` mainLoop can block on each other:

- The driver's `altSyncTicker` fires `checkForGapInUnsafeQueue`, which calls `RequestL2Range` and blocks on the unbuffered `rangeRequests` send.
- Meanwhile mainLoop is in `onResult` → `promote` → `receivePayload`, blocked handing a synced payload back to the driver through the `unsafeL2Payloads` channel (capacity 10).
- The driver cannot drain `unsafeL2Payloads` because it is parked on its own send, and mainLoop cannot receive the range request because it is parked on its own send.

Neither side is permanently deadlocked (the driver gives up after 2s, mainLoop after 3s), but both immediately re-enter the same state, so this is a livelock: progress leaks through far slower than the chain produces blocks.

This is reachable whenever a node restarts with a large unsafe head gap. At opBNB's 250ms block time, a 60s restart already leaves a ~240 block gap, which is enough to keep both paths permanently active. Sequencers are unaffected
because they produce the unsafe head and never have a gap.

Buffering `rangeRequests` removes one edge of the cycle: the driver's send returns immediately, so its eventLoop stays free to drain `unsafeL2Payloads`.

The send is deliberately left blocking (`select` on the send and `ctx.Done()` rather than a non-blocking send with `default`), so that a client which is genuinely congested for more than 16 queued requests still surfaces it through
the existing `too busy with P2P results/requests` warning, and still runs the `activeRangeRequests` cleanup on that path.

Capacity 16 is chosen to bound staleness. Requests are enqueued by a single goroutine at most once per `altSyncTicker` tick (1s), so 16 slots hold at most ~16s of backlog, well above mainLoop's 3s worst-case iteration (`maxResultProcessing`) and small enough that queued requests still dedup against `inFlight` and the quarantine LRU when they are drained.

### Example

N/A

### Changes
Notable changes:
* `op-node/p2p/sync.go`: `rangeRequests` is now `make(chan rangeRequest, 16)` instead of unbuffered.

